### PR TITLE
Handle different normalizations when fetching an input matrix

### DIFF
--- a/src/stripepy/cli.py
+++ b/src/stripepy/cli.py
@@ -56,6 +56,14 @@ def parse_args():
     )
 
     cli.add_argument(
+        "-n",
+        "--normalization",
+        type=str,
+        default="NONE",
+        help="Normalization to fetch (default: 'NONE').",
+    )
+
+    cli.add_argument(
         "-b",
         "--genomic-belt",
         type=int,
@@ -143,7 +151,7 @@ def parse_args():
         args = vars(cli.parse_args())
 
     # Gather input parameters in dictionaries:
-    configs_input = {key: args[key] for key in ["contact-map", "resolution", "genomic_belt", "roi"]}
+    configs_input = {key: args[key] for key in ["contact-map", "resolution", "normalization", "genomic_belt", "roi"]}
     configs_thresholds = {
         key: args[key]
         for key in [
@@ -161,6 +169,7 @@ def parse_args():
     print("\nArguments:")
     print(f"--contact-map: {configs_input['contact-map']}")
     print(f"--resolution: {configs_input['resolution']}")
+    print(f"--normalization: {configs_input['normalization']}")
     print(f"--genomic-belt: {configs_input['genomic_belt']}")
     print(f"--roi: {configs_input['roi']}")
     print(f"--max-width: {configs_thresholds['max_width']}")

--- a/src/stripepy/main.py
+++ b/src/stripepy/main.py
@@ -73,7 +73,7 @@ def main():
         if configs_input["roi"] is not None:
             IO.create_folders_for_plots(f"{configs_output['output_folder']}/plots/{this_chr}")
 
-        I = f.fetch(this_chr).to_csr("full")
+        I = f.fetch(this_chr, normalization=configs_input["normalization"]).to_csr("full")
 
         # RoI:
         RoI = others.define_RoI(


### PR DESCRIPTION
- Added a flag (-n, --normalization) which can be used to specify an input normalization (default: 'NONE'); see cli.py.
- Changed the fetch command in main.py so that it now inputs the provided normalization.