### PR TITLE
Refactoring/step1

### DIFF
--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -11,7 +11,7 @@ from .configs import be_verbose
 from .utils import TDA, finders, regressions, stripe
 
 
-def log_transform(I: ss.csr_matrix) -> ss.csr_matrix:
+def _log_transform(I: ss.csr_matrix) -> ss.csr_matrix:
     I.data[np.isnan(I.data)] = 0
     I.eliminate_zeros()
     Iproc = I.log1p()
@@ -21,7 +21,7 @@ def log_transform(I: ss.csr_matrix) -> ss.csr_matrix:
 def step_1(I, genomic_belt, resolution, RoI=None, output_folder=None):
 
     print("1.1) Log-transformation...")
-    Iproc = log_transform(I)
+    Iproc = _log_transform(I)
 
     print("1.2) Focusing on a neighborhood of the main diagonal...")
     matrix_belt = int(genomic_belt / resolution)

--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -1,4 +1,5 @@
 import time
+from typing import Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -25,6 +26,13 @@ def _band_extraction(I: ss.csr_matrix, resolution: int, genomic_belt: int) -> (s
     return LT_I, UT_I
 
 
+def _scale_Iproc(
+    I: ss.csr_matrix, LT_I: ss.csr_matrix, UT_I: ss.csr_matrix
+) -> Tuple[ss.csr_matrix, ss.csr_matrix, ss.csr_matrix]:
+    scaling_factor_Iproc = I.max()
+    return tuple(J / scaling_factor_Iproc for J in [I, LT_I, UT_I])  # noqa
+
+
 def step_1(I, genomic_belt, resolution, RoI=None, output_folder=None):
 
     print("1.1) Log-transformation...")
@@ -35,10 +43,7 @@ def step_1(I, genomic_belt, resolution, RoI=None, output_folder=None):
 
     # Scaling
     print("1.3) Projection onto [0, 1]...")
-    scaling_factor_Iproc = Iproc.max()
-    Iproc /= scaling_factor_Iproc
-    LT_Iproc /= scaling_factor_Iproc
-    UT_Iproc /= scaling_factor_Iproc
+    Iproc, LT_Iproc, UT_Iproc = _scale_Iproc(Iproc, LT_Iproc, UT_Iproc)
 
     if RoI is not None:
         print("1.4) Extracting a Region of Interest (RoI) for plot purposes...")

--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -1,5 +1,5 @@
 import time
-from typing import Tuple
+from typing import Dict, List, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,6 +33,12 @@ def _scale_Iproc(
     return tuple(J / scaling_factor_Iproc for J in [I, LT_I, UT_I])  # noqa
 
 
+def _extract_RoIs(I: ss.csr_matrix, RoI: Dict[str, List[int]]) -> ss.csr_matrix:
+    rows = cols = slice(RoI["matrix"][0], RoI["matrix"][1])
+    I_RoI = I[rows, cols].toarray()
+    return I_RoI
+
+
 def step_1(I, genomic_belt, resolution, RoI=None, output_folder=None):
 
     print("1.1) Log-transformation...")
@@ -47,9 +53,8 @@ def step_1(I, genomic_belt, resolution, RoI=None, output_folder=None):
 
     if RoI is not None:
         print("1.4) Extracting a Region of Interest (RoI) for plot purposes...")
-        rows = cols = slice(RoI["matrix"][0], RoI["matrix"][1])
-        I_RoI = I[rows, cols].toarray()
-        Iproc_RoI = Iproc[rows, cols].toarray()
+        I_RoI = _extract_RoIs(Iproc, RoI)
+        Iproc_RoI = _extract_RoIs(Iproc, RoI)
 
         if output_folder is not None:
 
@@ -71,8 +76,8 @@ def step_1(I, genomic_belt, resolution, RoI=None, output_folder=None):
                 compactify=False,
             )
     else:
-        I_RoI = None
-        Iproc_RoI = None
+        I_RoI = None  # TODO handle this case in _extract_RoIs
+        Iproc_RoI = None  # TODO handle this case in _extract_RoIs
 
     return LT_Iproc, UT_Iproc, Iproc_RoI
 

--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -39,25 +39,15 @@ def _extract_RoIs(I: ss.csr_matrix, RoI: Dict[str, List[int]]) -> ss.csr_matrix:
     return I_RoI
 
 
-def step_1(I, genomic_belt, resolution, RoI=None, output_folder=None):
+def _plot_RoIs(I, Iproc, RoI, output_folder):
 
-    print("1.1) Log-transformation...")
-    Iproc = _log_transform(I)
-
-    print("1.2) Focusing on a neighborhood of the main diagonal...")
-    LT_Iproc, UT_Iproc = _band_extraction(Iproc, resolution, genomic_belt)
-
-    # Scaling
-    print("1.3) Projection onto [0, 1]...")
-    Iproc, LT_Iproc, UT_Iproc = _scale_Iproc(Iproc, LT_Iproc, UT_Iproc)
-
+    # TODO rea1991 Once there is better test coverage, reqrite this as suggested in in #16
     if RoI is not None:
         print("1.4) Extracting a Region of Interest (RoI) for plot purposes...")
-        I_RoI = _extract_RoIs(Iproc, RoI)
+        I_RoI = _extract_RoIs(I, RoI)
         Iproc_RoI = _extract_RoIs(Iproc, RoI)
 
         if output_folder is not None:
-
             # Plots:
             IO.HiC(
                 I_RoI,
@@ -76,8 +66,22 @@ def step_1(I, genomic_belt, resolution, RoI=None, output_folder=None):
                 compactify=False,
             )
     else:
-        I_RoI = None  # TODO handle this case in _extract_RoIs
         Iproc_RoI = None  # TODO handle this case in _extract_RoIs
+    return Iproc_RoI
+
+
+def step_1(I, genomic_belt, resolution, RoI=None, output_folder=None):
+
+    print("1.1) Log-transformation...")
+    Iproc = _log_transform(I)
+
+    print("1.2) Focusing on a neighborhood of the main diagonal...")
+    LT_Iproc, UT_Iproc = _band_extraction(Iproc, resolution, genomic_belt)
+
+    print("1.3) Projection onto [0, 1]...")
+    Iproc, LT_Iproc, UT_Iproc = _scale_Iproc(Iproc, LT_Iproc, UT_Iproc)
+
+    Iproc_RoI = _plot_RoIs(I, Iproc, RoI, output_folder)
 
     return LT_Iproc, UT_Iproc, Iproc_RoI
 

--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -13,6 +13,7 @@ from .utils import TDA, finders, regressions, stripe
 
 
 def _log_transform(I: ss.csr_matrix) -> ss.csr_matrix:
+    # obikenobi23 This function is already tested inside test_stripepy.py, but it could be useful to have a look
     I.data[np.isnan(I.data)] = 0
     I.eliminate_zeros()
     Iproc = I.log1p()
@@ -20,6 +21,9 @@ def _log_transform(I: ss.csr_matrix) -> ss.csr_matrix:
 
 
 def _band_extraction(I: ss.csr_matrix, resolution: int, genomic_belt: int) -> (ss.csr_matrix, ss.csr_matrix):
+    # This function takes an input matrix, and returns:
+    # -) a lower-triangular matrix, where only the first int(genomic_belt / resolution) diagonals are kept
+    # -) a upper-triangular matrix, where only the first int(genomic_belt / resolution) diagonals are kept
     matrix_belt = int(genomic_belt / resolution)
     LT_I = ss.tril(I, k=0, format="csr") - ss.tril(I, k=-matrix_belt, format="csr")
     UT_I = ss.triu(I, k=0, format="csr") - ss.triu(I, k=matrix_belt, format="csr")
@@ -29,19 +33,25 @@ def _band_extraction(I: ss.csr_matrix, resolution: int, genomic_belt: int) -> (s
 def _scale_Iproc(
     I: ss.csr_matrix, LT_I: ss.csr_matrix, UT_I: ss.csr_matrix
 ) -> Tuple[ss.csr_matrix, ss.csr_matrix, ss.csr_matrix]:
+    # This function takes three matrices: a matrix I and its lower- and upper-triangular parts denoted by LT_I and UT_I.
+    # It divides the entries by the maximum entry of I
     scaling_factor_Iproc = I.max()
     return tuple(J / scaling_factor_Iproc for J in [I, LT_I, UT_I])  # noqa
 
 
 def _extract_RoIs(I: ss.csr_matrix, RoI: Dict[str, List[int]]) -> ss.csr_matrix:
+    # This function takes as input a matrix I and extract a region of interest (i.e., a subregion), whose matricial
+    # coordinates are contained in the dictionary RoI
     rows = cols = slice(RoI["matrix"][0], RoI["matrix"][1])
     I_RoI = I[rows, cols].toarray()
     return I_RoI
 
 
 def _plot_RoIs(I, Iproc, RoI, output_folder):
+    # This function calls _extract_RoIs to extract subregions of the matrices I and Iproc (if RoI is not None). If
+    # output_folder is not None, it generates plots and saves in the fiven path.
 
-    # TODO rea1991 Once there is better test coverage, reqrite this as suggested in in #16
+    # TODO rea1991 Once there is better test coverage, rewrite this as suggested in in #16
     if RoI is not None:
         print("1.4) Extracting a Region of Interest (RoI) for plot purposes...")
         I_RoI = _extract_RoIs(I, RoI)

--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -18,16 +18,20 @@ def _log_transform(I: ss.csr_matrix) -> ss.csr_matrix:
     return Iproc
 
 
+def _band_extraction(I: ss.csr_matrix, resolution: int, genomic_belt: int) -> (ss.csr_matrix, ss.csr_matrix):
+    matrix_belt = int(genomic_belt / resolution)
+    LT_I = ss.tril(I, k=0, format="csr") - ss.tril(I, k=-matrix_belt, format="csr")
+    UT_I = ss.triu(I, k=0, format="csr") - ss.triu(I, k=matrix_belt, format="csr")
+    return LT_I, UT_I
+
+
 def step_1(I, genomic_belt, resolution, RoI=None, output_folder=None):
 
     print("1.1) Log-transformation...")
     Iproc = _log_transform(I)
 
     print("1.2) Focusing on a neighborhood of the main diagonal...")
-    matrix_belt = int(genomic_belt / resolution)
-
-    LT_Iproc = ss.tril(Iproc, k=0, format="csr") - ss.tril(Iproc, k=-matrix_belt, format="csr")
-    UT_Iproc = ss.triu(Iproc, k=0, format="csr") - ss.triu(Iproc, k=matrix_belt, format="csr")
+    LT_Iproc, UT_Iproc = _band_extraction(Iproc, resolution, genomic_belt)
 
     # Scaling
     print("1.3) Projection onto [0, 1]...")

--- a/src/stripepy/utils/stripe.py
+++ b/src/stripepy/utils/stripe.py
@@ -4,6 +4,13 @@ import numpy as np
 class Stripe:
 
     def __init__(self, seed=None, left_bw=None, right_bw=None, upp_bw=None, low_bw=None, top_pers=None, where=None):
+
+        # TODO: robomics
+        # -) make left_bw, right_bw, upp_bw, and low_bw positional and mandatory
+        # -) where should be optional keyword: if not specified, it can be determined by the four mandatory values
+        # -) top_pers is in [0, +inf]
+        # -) where is "lower_triangular", "upper_triangular", or None (if not set)
+
         self.seed = seed
         self.persistence = top_pers
         self.L_bound = left_bw
@@ -17,6 +24,9 @@ class Stripe:
         self.RoI = None
 
     def compute_biodescriptors(self, I):
+
+        # TODO: robomics
+        # Check coordinates
 
         if self.where == "lower_triangular":
             convex_comb = int(round(0.99 * self.U_bound + 0.01 * self.D_bound))
@@ -101,10 +111,11 @@ class Stripe:
                     * 100
                 )
                 if self.outer_descriptors["mean"] != 0
-                else -1.0
+                else -1.0  # TODO rea1991: check if nan is more suitable
             )
 
         else:
+            # TODO rea1991 Check if still a problem, otherwise remove!
             self.inner_descriptors["five-number"] = [-1, -1, -1, -1, -1]
             self.inner_descriptors["mean"] = -1
             self.inner_descriptors["std"] = -1

--- a/test/test_stripepy.py
+++ b/test/test_stripepy.py
@@ -1,21 +1,21 @@
 import numpy as np
 import scipy.sparse as ss
 
-from stripepy.stripepy import log_transform
+from stripepy.stripepy import _log_transform
 
 
 class TestLogTransform:
 
     def test_empty(self):
         I = ss.csr_matrix((0, 0), dtype=float)
-        Iproc = log_transform(I)
+        Iproc = _log_transform(I)
 
         assert Iproc.shape == (0, 0)
         assert np.issubdtype(I.dtype, np.floating)
 
     def test_all_finite(self):
         I = ss.rand(100, 100, density=0.5, format="csr")
-        Iproc = log_transform(I)
+        Iproc = _log_transform(I)
 
         assert I.size == Iproc.size
         assert I.shape == Iproc.shape
@@ -28,7 +28,7 @@ class TestLogTransform:
         num_nan_values = (I.data >= mean_I).sum()
         I.data[I.data >= mean_I] = np.nan
 
-        Iproc = log_transform(I)
+        Iproc = _log_transform(I)
 
         assert np.isfinite(Iproc.data).all()
         assert Iproc.size == size_I - num_nan_values


### PR DESCRIPTION
step_1 is re-organized:
- it is decomposed into simpler functions so that it is easier to implement unit testing
- these simpler functions have a single-leading underscore in their names as "internal use" indicator
- to comply to the previous point, log_transform is renamed as _ log_transform