### PR TITLE
Implement stripepy download

### DIFF
--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -159,7 +159,7 @@ def run(
         dset_name, config = _lookup_dataset(name, assembly, max_size)
 
     if output_path is None:
-        output_path = pathlib.Path(f"{dset_name}.{config["format"]}")
+        output_path = pathlib.Path(f"{dset_name}." + config["format"])
 
     if output_path.exists() and not force:
         raise RuntimeError(f"refusing to overwrite file {output_path}. Pass --force to overwrite.")

--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -111,23 +111,23 @@ def _download_and_checksum(name: str, url: str, md5sum: str, dest: pathlib.Path)
 
 
 def run(
-    reference_genome: Union[str, None],
     name: Union[str, None],
     output_path: Union[pathlib.Path, None],
+    assembly: Union[str, None],
     list_only: bool,
     force: bool,
 ):
     t0 = time.time()
     if list_only:
-        _list_configs()
+        _list_datasets()
         return
 
-    random_sample = name is None and reference_genome is None
+    do_random_sample = name is None and assembly is None
 
-    if random_sample:
+    if do_random_sample:
         dset_name, config = _get_random_dataset()
     else:
-        dset_name, config = _lookup_dataset(name, reference_genome)
+        dset_name, config = _lookup_dataset(name, assembly)
 
     if output_path is None:
         output_path = pathlib.Path(f"{dset_name}.{config["format"]}")

--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -28,6 +28,13 @@ def _get_datasets(max_size: float) -> Dict[str, Dict[str, str]]:
             "format": "hic",
             "size_mb": 248.10,
         },
+        "4DNFIC1CLPK7": {
+            "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/0dc0b1ba-5509-4464-9814-dfe103ff09a0/4DNFIC1CLPK7.hic",
+            "md5": "9648c38d52fb467846cce42a4a072f57",
+            "assembly": "galGal5",
+            "format": "hic",
+            "size_mb": 583.57,
+        },
     }
 
     valid_dsets = {k: v for k, v in datasets.items() if v.get("size_mb", math.inf) < max_size}

--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -114,7 +114,6 @@ def run(
     reference_genome: Union[str, None],
     name: Union[str, None],
     output_path: Union[pathlib.Path, None],
-    random_sample: bool,
     list_only: bool,
     force: bool,
 ):
@@ -122,6 +121,8 @@ def run(
     if list_only:
         _list_configs()
         return
+
+    random_sample = name is None and reference_genome is None
 
     if random_sample:
         dset_name, config = _get_random_dataset()

--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -78,10 +78,10 @@ def _download_progress_reporter(chunk_no, max_chunk_size, download_size):
     timepoint = _download_progress_reporter.timepoint
 
     if time.time() - timepoint >= 15:
-        mb_downloaded = (chunk_no * max_chunk_size) / 1.0e6
-        download_size_mb = download_size / 1.0e6
+        mb_downloaded = (chunk_no * max_chunk_size) / (1024 << 10)
+        download_size_mb = download_size / (1024 << 10)
         progress_pct = (mb_downloaded / download_size_mb) * 100
-        logging.info("downloaded %.2f/%.2fMBs (%.2f%%)", mb_downloaded, download_size_mb, progress_pct)
+        logging.info("downloaded %.2f/%.2f MB (%.2f%%)", mb_downloaded, download_size_mb, progress_pct)
         _download_progress_reporter.timepoint = time.time()
 
 
@@ -140,4 +140,4 @@ def run(
     t1 = time.time()
 
     logging.info('successfully downloaded dataset "%s" to file "%s"', config["url"], dest)
-    logging.info(f"file size: %.2fMB. Elapsed time: %.2fs", dest.stat().st_size / 1.0e6, t1 - t0)
+    logging.info(f"file size: %.2fMB. Elapsed time: %.2fs", dest.stat().st_size / (1024 << 10), t1 - t0)

--- a/src/stripepy/cli/setup.py
+++ b/src/stripepy/cli/setup.py
@@ -1,4 +1,5 @@
 import argparse
+import math
 import pathlib
 from importlib.metadata import version
 from typing import Any, Dict, Tuple
@@ -30,6 +31,13 @@ def _probability(arg) -> float:
         return n
 
     raise ValueError("Not a valid probability")
+
+
+def _non_zero_positive_float(arg) -> float:
+    if (n := float(arg)) > 0:
+        return n
+
+    raise ValueError("Not a non-zero, positive float")
 
 
 def _make_stripepy_call_subcommand(main_parser) -> argparse.ArgumentParser:
@@ -166,6 +174,13 @@ def _make_stripepy_download_subcommand(main_parser) -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Print the list of available datasets and return.",
+    )
+
+    sc.add_argument(
+        "--max-size",
+        type=_non_zero_positive_float,
+        default=512.0,
+        help="Upper bound for the size of the files to be considered when --name is not provided.",
     )
     sc.add_argument(
         "-o",

--- a/src/stripepy/cli/setup.py
+++ b/src/stripepy/cli/setup.py
@@ -145,6 +145,7 @@ def _make_stripepy_download_subcommand(main_parser) -> argparse.ArgumentParser:
 
     def get_avail_ref_genomes():
         from .download import _get_datasets
+
         return {record["assembly"] for record in _get_datasets(math.inf).values() if "assembly" in record}
 
     grp = sc.add_mutually_exclusive_group(required=False)
@@ -157,7 +158,8 @@ def _make_stripepy_download_subcommand(main_parser) -> argparse.ArgumentParser:
     grp.add_argument(
         "--name",
         type=str,
-        help="Name of the dataset to be downloaded.",
+        help="Name of the dataset to be downloaded.\n"
+        "When not provided, randomly select and download a dataset based on the provided CLI options (if any).",
     )
     grp.add_argument(
         "--list-only",

--- a/src/stripepy/cli/setup.py
+++ b/src/stripepy/cli/setup.py
@@ -147,7 +147,6 @@ def _make_stripepy_download_subcommand(main_parser) -> argparse.ArgumentParser:
     grp.add_argument(
         "--reference-genome",
         type=str,
-        default="dm6",
         choices={"dm6"},
         help="Restrict downloads to the given reference genome.",
     )

--- a/src/stripepy/cli/setup.py
+++ b/src/stripepy/cli/setup.py
@@ -143,12 +143,16 @@ def _make_stripepy_download_subcommand(main_parser) -> argparse.ArgumentParser:
         help="Helper command to simplify downloading datasets that can be used to test StripePy.",
     )
 
+    def get_avail_ref_genomes():
+        from .download import _get_datasets
+        return {record["assembly"] for record in _get_datasets(math.inf).values() if "assembly" in record}
+
     grp = sc.add_mutually_exclusive_group(required=False)
     grp.add_argument(
-        "--reference-genome",
+        "--assembly",
         type=str,
-        choices={"dm6"},
-        help="Restrict downloads to the given reference genome.",
+        choices=get_avail_ref_genomes(),
+        help="Restrict downloads to the given reference genome assembly.",
     )
     grp.add_argument(
         "--name",

--- a/src/stripepy/cli/setup.py
+++ b/src/stripepy/cli/setup.py
@@ -157,19 +157,11 @@ def _make_stripepy_download_subcommand(main_parser) -> argparse.ArgumentParser:
         help="Name of the dataset to be downloaded.",
     )
     grp.add_argument(
-        "--random",
-        action="store_true",
-        default=False,
-        dest="random_sample",
-        help="Randomly select the dataset to be downloaded.",
-    )
-    grp.add_argument(
         "--list-only",
         action="store_true",
         default=False,
         help="Print the list of available datasets and return.",
     )
-
     sc.add_argument(
         "-o",
         "--output",

--- a/src/stripepy/cli/setup.py
+++ b/src/stripepy/cli/setup.py
@@ -137,6 +137,57 @@ def _make_stripepy_call_subcommand(main_parser) -> argparse.ArgumentParser:
     return sc
 
 
+def _make_stripepy_download_subcommand(main_parser) -> argparse.ArgumentParser:
+    sc: argparse.ArgumentParser = main_parser.add_parser(
+        "download",
+        help="Helper command to simplify downloading datasets that can be used to test StripePy.",
+    )
+
+    grp = sc.add_mutually_exclusive_group(required=False)
+    grp.add_argument(
+        "--reference-genome",
+        type=str,
+        default="dm6",
+        choices={"dm6"},
+        help="Restrict downloads to the given reference genome.",
+    )
+    grp.add_argument(
+        "--name",
+        type=str,
+        help="Name of the dataset to be downloaded.",
+    )
+    grp.add_argument(
+        "--random",
+        action="store_true",
+        default=False,
+        dest="random_sample",
+        help="Randomly select the dataset to be downloaded.",
+    )
+    grp.add_argument(
+        "--list-only",
+        action="store_true",
+        default=False,
+        help="Print the list of available datasets and return.",
+    )
+
+    sc.add_argument(
+        "-o",
+        "--output",
+        type=pathlib.Path,
+        dest="output_path",
+        help="Path where to store the downloaded file.",
+    )
+    sc.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Overwrite existing file(s).",
+    )
+
+    return sc
+
+
 def _make_cli() -> argparse.ArgumentParser:
     cli = argparse.ArgumentParser(
         description="stripepy is designed to recognize linear patterns in contact maps (.hic, .mcool, .cool) "
@@ -149,6 +200,7 @@ def _make_cli() -> argparse.ArgumentParser:
     )
 
     _make_stripepy_call_subcommand(sub_parser)
+    _make_stripepy_download_subcommand(sub_parser)
 
     cli.add_argument(
         "-v",
@@ -207,5 +259,7 @@ def parse_args() -> Tuple[str, Any]:
     subcommand = args.pop("subcommand")
     if subcommand == "call":
         return subcommand, *_process_stripepy_call_args(args)
+    if subcommand == "download":
+        return subcommand, args
 
     raise NotImplementedError

--- a/src/stripepy/main.py
+++ b/src/stripepy/main.py
@@ -1,8 +1,17 @@
+import logging
+
 from .cli import call, download, setup
+
+
+def _setup_logger(level: str):
+    fmt = "[%(asctime)s] %(levelname)s: %(message)s"
+    logging.basicConfig(level=level, format=fmt)
+    logging.getLogger().setLevel(level)
 
 
 def main():
     subcommand, args = setup.parse_args()
+    _setup_logger("INFO")  # TODO make tunable
 
     if subcommand == "call":
         return call.run(**args)

--- a/src/stripepy/main.py
+++ b/src/stripepy/main.py
@@ -1,4 +1,4 @@
-from .cli import call, setup
+from .cli import call, download, setup
 
 
 def main():
@@ -6,6 +6,8 @@ def main():
 
     if subcommand == "call":
         return call.run(**args)
+    if subcommand == "download":
+        return download.run(**args)
 
     raise NotImplementedError
 


### PR DESCRIPTION
StripePy download is a new subcommand that aims to simplify downloading datasets that can be used to test StripePy.

Example usage:

```bash
# List the available datasets
stripepy download --list-only

# Randomly select and download one of the datasets
stripepy download

# Randomly select and download a dataset using --max-size as upper bound for the file size
stripepy download --max-size 512

# Override the output file location
stripepy download -o my_precious.hic

# Download the given dataset
stripepy download --name 4DNFIOTPSS3L

# Randomly select and download a dataset for the given reference genome
stripepy download --refrence-genome dm6
```