### PR TITLE
Add --nproc to stripepy call

### DIFF
--- a/src/stripepy/cli/setup.py
+++ b/src/stripepy/cli/setup.py
@@ -1,5 +1,6 @@
 import argparse
 import math
+import multiprocessing as mp
 import pathlib
 from importlib.metadata import version
 from typing import Any, Dict, Tuple
@@ -9,6 +10,17 @@ from typing import Any, Dict, Tuple
 class CustomFormatter(argparse.RawTextHelpFormatter):
     def _fill_text(self, text, width, indent):
         return "".join([indent + line + "\n" for line in text.splitlines()])
+
+
+def _num_cpus(arg: str) -> int:
+    try:
+        n = int(arg)
+        if 0 < n <= mp.cpu_count():
+            return n
+    except:  # noqa
+        pass
+
+    raise ValueError(f"Not a valid number of CPU cores (allowed values are integers between 1 and {mp.cpu_count()})")
 
 
 def _existing_file(arg: str) -> pathlib.Path:
@@ -150,6 +162,14 @@ def _make_stripepy_call_subcommand(main_parser) -> argparse.ArgumentParser:
         help="Overwrite existing file(s).",
     )
 
+    sc.add_argument(
+        "-p",
+        "--nproc",
+        type=_num_cpus,
+        default=1,
+        help="Maximum number of parallel processes to use.",
+    )
+
     return sc
 
 
@@ -252,7 +272,7 @@ def _process_stripepy_call_args(args: Dict[str, Any]) -> Dict[str, Any]:
             "max_width",
         ]
     }
-    configs_output = {key: args[key] for key in ["output_folder", "force"]}
+    configs_output = {key: args[key] for key in ["output_folder", "force", "nproc"]}
 
     # Print the used parameters (chosen or default-ones):
     print("\nArguments:")
@@ -269,6 +289,7 @@ def _process_stripepy_call_args(args: Dict[str, Any]) -> Dict[str, Any]:
     print(f"--loc-trend-min: {configs_thresholds['loc_trend_min']}")
     print(f"--output-folder: {configs_output['output_folder']}")
     print(f"--force: {configs_output['force']}")
+    print(f"--nproc: {configs_output['nproc']}")
 
     return {"configs_input": configs_input, "configs_thresholds": configs_thresholds, "configs_output": configs_output}
 

--- a/src/stripepy/cli/setup.py
+++ b/src/stripepy/cli/setup.py
@@ -272,7 +272,9 @@ def _process_stripepy_call_args(args: Dict[str, Any]) -> Dict[str, Any]:
             "max_width",
         ]
     }
-    configs_output = {key: args[key] for key in ["output_folder", "force", "nproc"]}
+    configs_output = {key: args[key] for key in ["output_folder", "force"]}
+
+    configs_other = {"nproc": args["nproc"]}
 
     # Print the used parameters (chosen or default-ones):
     print("\nArguments:")
@@ -289,9 +291,14 @@ def _process_stripepy_call_args(args: Dict[str, Any]) -> Dict[str, Any]:
     print(f"--loc-trend-min: {configs_thresholds['loc_trend_min']}")
     print(f"--output-folder: {configs_output['output_folder']}")
     print(f"--force: {configs_output['force']}")
-    print(f"--nproc: {configs_output['nproc']}")
+    print(f"--nproc: {configs_other['nproc']}")
 
-    return {"configs_input": configs_input, "configs_thresholds": configs_thresholds, "configs_output": configs_output}
+    return {
+        "configs_input": configs_input,
+        "configs_thresholds": configs_thresholds,
+        "configs_output": configs_output,
+        "configs_other": configs_other,
+    }
 
 
 def parse_args() -> Tuple[str, Any]:

--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -472,6 +472,7 @@ def step_3(
     Iproc_RoI=None,
     RoI=None,
     output_folder=None,
+    map=map,
 ):
 
     # Retrieve data:
@@ -507,8 +508,12 @@ def step_3(
     # Choose the variable criterion between max_ascent and max_perc_descent
     # ---> When variable criterion is set to max_ascent, set the variable max_ascent
     # ---> When variable criterion is set to max_perc_descent, set the variable max_perc_descent
-    LT_HIoIs = finders.find_HIoIs(LT_pseudo_distrib, LT_MPs, LT_bounded_mPs, int(max_width / (2 * resolution)) + 1)
-    UT_HIoIs = finders.find_HIoIs(UT_pseudo_distrib, UT_MPs, UT_bounded_mPs, int(max_width / (2 * resolution)) + 1)
+    LT_HIoIs = finders.find_HIoIs(
+        LT_pseudo_distrib, LT_MPs, LT_bounded_mPs, int(max_width / (2 * resolution)) + 1, map=map
+    )
+    UT_HIoIs = finders.find_HIoIs(
+        UT_pseudo_distrib, UT_MPs, UT_bounded_mPs, int(max_width / (2 * resolution)) + 1, map=map
+    )
 
     # List of left or right boundaries:
     LT_L_bounds, LT_R_bounds = map(list, zip(*LT_HIoIs))
@@ -652,6 +657,7 @@ def step_3(
             min_persistence=loc_pers_min,
             where="lower",
             output_folder=f"{output_folder}local_pseudodistributions/",
+            map=map,
         )
         UT_VIoIs, UT_peaks_ids = finders.find_VIoIs(
             U,
@@ -663,6 +669,7 @@ def step_3(
             min_persistence=loc_pers_min,
             where="upper",
             output_folder=f"{output_folder}local_pseudodistributions/",
+            map=map,
         )
     else:
         LT_VIoIs, LT_peaks_ids = finders.find_VIoIs(
@@ -675,6 +682,7 @@ def step_3(
             min_persistence=loc_pers_min,
             where="lower",
             output_folder=None,
+            map=map,
         )
         UT_VIoIs, UT_peaks_ids = finders.find_VIoIs(
             U,
@@ -686,6 +694,7 @@ def step_3(
             min_persistence=loc_pers_min,
             where="upper",
             output_folder=None,
+            map=map,
         )
 
     # List of left or right boundaries:

--- a/src/stripepy/utils/finders.py
+++ b/src/stripepy/utils/finders.py
@@ -182,7 +182,7 @@ def find_upper_v_domain(I, VIoIs2plot, threshold_cut, max_height, min_persistenc
     return Vdomain_and_peaks
 
 
-def find_HIoIs(pd, seed_sites, seed_site_bounds, max_width):
+def find_HIoIs(pd, seed_sites, seed_site_bounds, max_width, map=map):
     """
     :param pd:                  acronym for pseudo-distribution, but can be any 1D array representing a uniformly-sample
                                 scalar function works
@@ -192,6 +192,7 @@ def find_HIoIs(pd, seed_sites, seed_site_bounds, max_width):
                                 (*) seed_site_bounds[i] is the left boundary
                                 (*) seed_site_bounds[i+1] is the right boundary
     :param max_width:           maximum width allowed
+    :param map:                 alternative implementation of the built-in map function. Can be used to e.g. run this step in parallel by passing multiprocessing.Pool().map.
     :return:
     HIoIs                       list of lists, where each sublist is a pair consisting of the left and right boundaries
     """
@@ -200,10 +201,8 @@ def find_HIoIs(pd, seed_sites, seed_site_bounds, max_width):
         (seed_site, seed_site_bounds[num_MP], seed_site_bounds[num_MP + 1])
         for num_MP, seed_site in enumerate(seed_sites)
     ]
-    with Pool() as pool:
-        HIoIs = pool.map(partial(find_horizontal_domain, pd, max_width=max_width), iterable_input)
-        pool.close()
-        pool.join()
+
+    HIoIs = map(partial(find_horizontal_domain, pd, max_width=max_width), iterable_input)
 
     # Handle possible overlapping intervals:
     for i in range(len(HIoIs) - 1):
@@ -226,6 +225,7 @@ def find_VIoIs(
     VIoIs2plot=None,
     output_folder=None,
     where="lower",
+    map=map,
 ):
 
     # Triplets to use in multiprocessing:
@@ -233,30 +233,21 @@ def find_VIoIs(
 
     # Lower-triangular part of the Hi-C matrix:
     if where == "lower":
-
-        with Pool() as pool:
-
-            Vdomains_and_peaks = pool.map(
-                partial(find_lower_v_domain, I, VIoIs2plot, threshold_cut, max_height, min_persistence, output_folder),
-                iterable_input,
-            )
-            pool.close()
-            pool.join()
+        Vdomains_and_peaks = map(
+            partial(find_lower_v_domain, I, VIoIs2plot, threshold_cut, max_height, min_persistence, output_folder),
+            iterable_input,
+        )
 
         VIoIs, peak_locs = list(zip(*Vdomains_and_peaks))
 
     # Upper-triangular part of the Hi-C matrix:
     elif where == "upper":
+        # HIoIs = pool.map(partial(find_h_domain, pd), iterable_input)
 
-        with Pool() as pool:
-            # HIoIs = pool.map(partial(find_h_domain, pd), iterable_input)
-
-            Vdomains_and_peaks = pool.map(
-                partial(find_upper_v_domain, I, VIoIs2plot, threshold_cut, max_height, min_persistence, output_folder),
-                iterable_input,
-            )
-            pool.close()
-            pool.join()
+        Vdomains_and_peaks = map(
+            partial(find_upper_v_domain, I, VIoIs2plot, threshold_cut, max_height, min_persistence, output_folder),
+            iterable_input,
+        )
 
         VIoIs, peak_locs = list(zip(*Vdomains_and_peaks))
 


### PR DESCRIPTION
- Add new `--nproc` flag to control the maximum level of parallelism used by `stripepy call`
- Reuse process pools as much as possible