### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+#
+# SPDX-License-Identifier: MIT
+
+# Ignore everything
+**
+
+# Allowed directories
+!src/**/*.py
+!test/**/*.py
+
+
+# Allowed files
+!LICENCE
+!pyproject.toml
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ COPY --from=tester "$src_dir/LICENCE" /opt/stripepy/share/licenses/stripepy/LICE
 
 WORKDIR /data
 ENTRYPOINT ["/opt/stripepy/bin/stripepy"]
-ENV PATH "$PATH:/opt/stripepy/bin"
+ENV PATH="$PATH:/opt/stripepy/bin"
 
 RUN stripepy --help
 RUN stripepy --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,88 @@
+# Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+#
+# SPDX-License-Identifier: MIT
+
+##### IMPORTANT #####
+# This Dockerfile requires several build arguments to be defined through --build-arg
+# See utils/devel/build_dockerfile.sh for an example of how to build this Dockerfile
+#####################
+
+ARG BASE_IMAGE
+ARG BASE_IMAGE_DIGEST
+FROM "${BASE_IMAGE}@${BASE_IMAGE_DIGEST}" AS builder
+
+ARG GIT_HASH
+ARG CREATION_DATE
+ARG VERSION
+
+RUN if [ -z "$GIT_HASH" ]; then echo "Missing GIT_HASH --build-arg" && exit 1; fi \
+&&  if [ -z "$CREATION_DATE" ]; then echo "Missing CREATION_DATE --build-arg" && exit 1; fi \
+&&  if [ -z "$VERSION" ]; then echo "Missing VERSION --build-arg" && exit 1; fi
+
+ARG SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION"
+ARG src_dir='/root/stripepy'
+ARG install_dir='/opt/stripepy'
+
+COPY . "$src_dir/"
+
+RUN python3 -m venv "$install_dir" \
+&& "$install_dir/bin/pip" install "$src_dir" -v
+
+
+ARG BASE_IMAGE
+ARG BASE_IMAGE_DIGEST
+FROM "${BASE_IMAGE}@${BASE_IMAGE_DIGEST}" AS tester
+
+ARG VERSION
+
+ARG SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION"
+ARG src_dir='/root/stripepy'
+ARG install_dir='/opt/stripepy'
+
+COPY --from=builder "$src_dir" "$src_dir"
+COPY --from=builder "$install_dir" "$install_dir"
+
+RUN "$install_dir/bin/pip" install "$src_dir[test]" -v
+
+RUN ls -lah "$src_dir"
+
+RUN "$install_dir/bin/python3" -m pytest "$src_dir/test"
+
+
+ARG BASE_IMAGE
+ARG BASE_IMAGE_DIGEST
+FROM "${BASE_IMAGE}@${BASE_IMAGE_DIGEST}" AS base
+
+ARG BASE_IMAGE
+ARG BASE_IMAGE_DIGEST
+ARG GIT_HASH
+ARG CREATION_DATE
+ARG VERSION
+
+ARG src_dir='/root/stripepy'
+ARG install_dir='/opt/stripepy'
+
+COPY --from=builder "$install_dir" /opt/stripepy/
+COPY --from=tester "$src_dir/LICENCE" /opt/stripepy/share/licenses/stripepy/LICENCE
+
+WORKDIR /data
+ENTRYPOINT ["/opt/stripepy/bin/stripepy"]
+ENV PATH "$PATH:/opt/stripepy/bin"
+
+RUN stripepy --help
+RUN stripepy --version
+
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
+LABEL org.opencontainers.image.authors='Andrea Raffo <andrea.raffo@ibv.uio.no>,Roberto Rossini <roberros@uio.no>'
+LABEL org.opencontainers.image.url='https://github.com/paulsengroup/stripepy'
+LABEL org.opencontainers.image.documentation='https://github.com/paulsengroup/stripepy'
+LABEL org.opencontainers.image.source='https://github.com/paulsengroup/stripepy'
+LABEL org.opencontainers.image.licenses='MIT'
+LABEL org.opencontainers.image.title='StripePy'
+LABEL org.opencontainers.image.description='StripePy recognizes linear patterns in chromosome conformation capture contact maps using geometric reasoning'
+LABEL org.opencontainers.image.base.digest="$BASE_IMAGE_DIGEST"
+LABEL org.opencontainers.image.base.name="$BASE_IMAGE"
+
+LABEL org.opencontainers.image.revision="$GIT_HASH"
+LABEL org.opencontainers.image.created="$CREATION_DATE"
+LABEL org.opencontainers.image.version="$VERSION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,6 @@ COPY --from=builder "$install_dir" "$install_dir"
 
 RUN "$install_dir/bin/pip" install "$src_dir[test]" -v
 
-RUN ls -lah "$src_dir"
-
 RUN "$install_dir/bin/python3" -m pytest "$src_dir/test"
 
 

--- a/utils/devel/build_dockerfile.sh
+++ b/utils/devel/build_dockerfile.sh
@@ -17,19 +17,18 @@ if [ $ARGC -gt 2 ]; then
   exit 1
 fi
 
-if [ $ARGC -eq 1 ]; then
-  PLATFORM="$1"
-else
-  PLATFORM='linux/amd64'
-fi
-
-
 IMAGE_NAME='stripepy'
 
 if [ "$(uname)" == "Darwin" ]; then
   BUILD_USER="$USER"
 else
   BUILD_USER='root'
+fi
+
+if [ $ARGC -eq 1 ]; then
+  PLATFORM="$1"
+else
+  PLATFORM="$(sudo -u "$BUILD_USER" docker info --format '{{ .OSType }}/{{ .Architecture }}')"
 fi
 
 venv_dir="$(mktemp -d)"

--- a/utils/devel/build_dockerfile.sh
+++ b/utils/devel/build_dockerfile.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Roberto Rossini <roberros@uio.no>
+#
+# SPDX-License-Identifier: MIT
+
+set -e
+set -u
+set -o pipefail
+
+ARGC=$#
+
+if [ $ARGC -gt 2 ]; then
+  1>&2 echo "Usage:   $0 [platform]"
+  1>&2 echo "Example: $0 linux/amd64"
+  1>&2 echo "Example: $0 linux/amd64,linux/arm64"
+  exit 1
+fi
+
+if [ $ARGC -eq 1 ]; then
+  PLATFORM="$1"
+else
+  PLATFORM='linux/amd64'
+fi
+
+
+IMAGE_NAME='stripepy'
+
+if [ "$(uname)" == "Darwin" ]; then
+  BUILD_USER="$USER"
+else
+  BUILD_USER='root'
+fi
+
+venv_dir="$(mktemp -d)"
+
+trap "rm -rf '$venv_dir'" EXIT
+
+python3 -m venv "$venv_dir"
+
+"$venv_dir/bin/pip" install hatchling hatch_vcs
+VERSION="$("$venv_dir/bin/hatchling" version)"
+
+GIT_HASH="$(git rev-parse HEAD)"
+GIT_SHORT_HASH="$(git rev-parse --short HEAD)"
+GIT_TAG="$(git for-each-ref 'refs/tags/v*.*.*' --count 1 --sort=-v:refname --format "%(refname:short)" --points-at HEAD)"
+CREATION_DATE="$(date -I)"
+
+if [[ $(git status --porcelain -uno) ]]; then
+  GIT_IS_DIRTY=1
+else
+  GIT_IS_DIRTY=0
+fi
+
+IMAGE_TAG="sha-$GIT_SHORT_HASH"
+if [ $GIT_IS_DIRTY -ne 0 ]; then
+  IMAGE_TAG+='-dirty'
+fi
+
+if [ -z "$GIT_TAG" ]; then
+  GIT_TAG="sha-$GIT_SHORT_HASH"
+else
+  GIT_TAG="$GIT_TAG"
+fi
+
+BASE_IMAGE='docker.io/library/python:3.12.7'
+2>&1 echo "Building \"$IMAGE_NAME:$IMAGE_TAG\" for platform $PLATFORM..."
+
+sudo -u "$BUILD_USER" docker pull "$BASE_IMAGE"
+BASE_IMAGE_DIGEST="$(sudo -u "$BUILD_USER" docker inspect --format='{{index .RepoDigests 0}}' "$BASE_IMAGE" | cut -f 2 -d '@')"
+
+sudo -u "$BUILD_USER" docker buildx build --platform "$PLATFORM" --load \
+  --build-arg "BASE_IMAGE=$BASE_IMAGE" \
+  --build-arg "BASE_IMAGE_DIGEST=$BASE_IMAGE_DIGEST" \
+  --build-arg "GIT_HASH=$GIT_HASH" \
+  --build-arg "CREATION_DATE=$CREATION_DATE" \
+  --build-arg "VERSION=$VERSION" \
+  -t "$IMAGE_NAME:latest" \
+  -t "$IMAGE_NAME:$(echo "$CREATION_DATE" | tr -d '\-' )" \
+  -t "$IMAGE_NAME:$IMAGE_TAG" \
+  "$(git rev-parse --show-toplevel)"
+
+ # sudo singularity build -F "${img_name}_v${ver}.sif" \
+ #                           "docker-daemon://${img_name}:${ver}"

--- a/utils/devel/build_dockerfile.sh
+++ b/utils/devel/build_dockerfile.sh
@@ -63,7 +63,7 @@ else
 fi
 
 BASE_IMAGE='docker.io/library/python:3.12.7'
-2>&1 echo "Building \"$IMAGE_NAME:$IMAGE_TAG\" for platform $PLATFORM..."
+2>&1 echo "Building \"$IMAGE_NAME:$IMAGE_TAG\" (stripepy v$VERSION) for platform $PLATFORM..."
 
 sudo -u "$BUILD_USER" docker pull "$BASE_IMAGE"
 BASE_IMAGE_DIGEST="$(sudo -u "$BUILD_USER" docker inspect --format='{{index .RepoDigests 0}}' "$BASE_IMAGE" | cut -f 2 -d '@')"


### PR DESCRIPTION
Add Dockerfile for StripePy.

The Dockerfile requires several `--build-arg` in order to build properly.

Script `utils/devel/build_dockerfile.sh` takes care of automatically infer all required build arguments and build a docker image targeting the native architecture.

Example usage:
```bash
utils/devel/build_dockerfile.sh

# Build for multiple archs
utils/devel/build_dockerfile.sh linux/amd64,linux/arm4
```
