### PR TITLE
Remove flag glob-pers-type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,6 @@ jobs:
             ${{ env.TEST_DATASET_ID }}.hic \
             100000 \
             -o stripepy/ \
-            --glob-pers-type constant \
             --glob-pers-min 0.10 \
             --loc-pers-min 0.33 \
             --loc-trend-min 0.25 \

--- a/src/stripepy/cli/call.py
+++ b/src/stripepy/cli/call.py
@@ -186,7 +186,6 @@ def run(
                     LT_Iproc,
                     UT_Iproc,
                     configs_input["resolution"],
-                    configs_thresholds["glob_pers_type"],
                     configs_thresholds["glob_pers_min"],
                     h5[f"{this_chr}/global-pseudo-distributions/"],
                     Iproc_RoI=Iproc_RoI,
@@ -198,7 +197,6 @@ def run(
                     LT_Iproc,
                     UT_Iproc,
                     configs_input["resolution"],
-                    configs_thresholds["glob_pers_type"],
                     configs_thresholds["glob_pers_min"],
                     h5[f"{this_chr}/global-pseudo-distributions/"],
                 )

--- a/src/stripepy/cli/setup.py
+++ b/src/stripepy/cli/setup.py
@@ -117,20 +117,11 @@ def _make_stripepy_call_subcommand(main_parser) -> argparse.ArgumentParser:
     )
 
     sc.add_argument(
-        "--glob-pers-type",
-        type=str,
-        choices=["constant", "adaptive"],
-        default="constant",
-        help="Type of thresholding to filter persistence maxima points and identify loci of interest (aka seeds).",
-    )
-
-    sc.add_argument(
         "--glob-pers-min",
         type=_probability,
-        default=None,
-        help="Threshold value between 0 and 1 to filter persistence maxima points and identify loci of interest "
-        "(aka seeds). The default value depends on the option --glob-pers-type (default: 0.2 if --glob-pers-type "
-        "set to 'constant', 0.9 if --glob-pers-type set to 'adaptive').",
+        default=0.2,
+        help="Threshold value between 0 and 1 to filter persistence maxima points and identify loci of interest, "
+        "aka seeds (default: 0.2).",
     )
 
     sc.add_argument(
@@ -291,18 +282,12 @@ def _make_cli() -> argparse.ArgumentParser:
 
 
 def _process_stripepy_call_args(args: Dict[str, Any]) -> Dict[str, Any]:
-    if args["glob_pers_min"] is None:
-        if args["glob_pers_type"] == "constant":
-            args["glob_pers_min"] = 0.2
-        else:
-            args["glob_pers_min"] = 0.9
 
     # Gather input parameters in dictionaries:
     configs_input = {key: args[key] for key in ["contact-map", "resolution", "normalization", "genomic_belt", "roi"]}
     configs_thresholds = {
         key: args[key]
         for key in [
-            "glob_pers_type",
             "glob_pers_min",
             "constrain_heights",
             "loc_pers_min",
@@ -322,7 +307,6 @@ def _process_stripepy_call_args(args: Dict[str, Any]) -> Dict[str, Any]:
     print(f"--genomic-belt: {configs_input['genomic_belt']}")
     print(f"--roi: {configs_input['roi']}")
     print(f"--max-width: {configs_thresholds['max_width']}")
-    print(f"--glob-pers-type: {configs_thresholds['glob_pers_type']}")
     print(f"--glob-pers-min: {configs_thresholds['glob_pers_min']}")
     print(f"--constrain-heights: {configs_thresholds['constrain_heights']}")
     print(f"--loc-pers-min: {configs_thresholds['loc_pers_min']}")

--- a/src/stripepy/main_over_MoDLE.py
+++ b/src/stripepy/main_over_MoDLE.py
@@ -40,7 +40,6 @@ if __name__ == "__main__":
                 }
 
                 configs_thresholds = {
-                    "glob_pers_type": "constant",
                     "glob_pers_min": 0.025,
                     "constrain_heights": True,
                     "loc_pers_min": 0.25,
@@ -86,7 +85,6 @@ if __name__ == "__main__":
                 print(f"--resolution: {configs_input['resolution']}")
                 print(f"--genomic-belt: {configs_input['genomic_belt']}")
                 print(f"--max-width: {configs_thresholds['max_width']}")
-                print(f"--glob-pers-type: {configs_thresholds['glob_pers_type']}")
                 print(f"--glob-pers-min: {configs_thresholds['glob_pers_min']}")
                 print(f"--constrain-heights: {configs_thresholds['constrain_heights']}")
                 print(f"--loc-pers-min: {configs_thresholds['loc_pers_min']}")
@@ -150,7 +148,6 @@ if __name__ == "__main__":
                             LT_Iproc,
                             UT_Iproc,
                             configs_input["resolution"],
-                            configs_thresholds["glob_pers_type"],
                             configs_thresholds["glob_pers_min"],
                             hf[f"{this_chr}/global-pseudo-distributions/"],
                             Iproc_RoI=Iproc_RoI,
@@ -162,7 +159,6 @@ if __name__ == "__main__":
                             LT_Iproc,
                             UT_Iproc,
                             configs_input["resolution"],
-                            configs_thresholds["glob_pers_type"],
                             configs_thresholds["glob_pers_min"],
                             hf[f"{this_chr}/global-pseudo-distributions/"],
                         )

--- a/utils/devel/test_docker_image.sh
+++ b/utils/devel/test_docker_image.sh
@@ -57,7 +57,6 @@ stripepy call \
   "$TEST_DATASET" \
   100000 \
   -o stripepy/ \
-  --glob-pers-type constant \
   --glob-pers-min 0.10 \
   --loc-pers-min 0.33 \
   --loc-trend-min 0.25 \


### PR DESCRIPTION
The flag glob-pers-type has been removed, as it was always used with its default option "constant".

This change partially addresses #58