### PR TITLE
Update the test datasets

### DIFF
--- a/.github/workflows/build-dockerfile.yml
+++ b/.github/workflows/build-dockerfile.yml
@@ -42,9 +42,9 @@ defaults:
     shell: bash
 
 env:
-  TEST_DATASET_ID: 4DNFIOTPSS3L
-  TEST_DATASET_URL: "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/7386f953-8da9-47b0-acb2-931cba810544/4DNFIOTPSS3L.hic"
-  TEST_DATASET_MD5: "d8b030bec6918bfbb8581c700990f49d"
+  TEST_DATASET_ID: 4DNFI9GMP2J8
+  TEST_DATASET_URL: "https://zenodo.org/records/14283922/files/4DNFI9GMP2J8.stripepy.mcool?download=1"
+  TEST_DATASET_MD5: "a17d08460c03cf6c926e2ca5743e4888"
 
 jobs:
   build-dockerfile:
@@ -77,13 +77,13 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ env.TEST_DATASET_ID }}
-          path: ${{ env.TEST_DATASET_ID }}.hic
+          path: ${{ env.TEST_DATASET_ID }}.mcool
 
       - name: Download test dataset
         if: steps.cache-dset.outputs.cache-hit != 'true'
         run: |
-          curl -L '${{ env.TEST_DATASET_URL }}' -o '${{ env.TEST_DATASET_ID }}.hic'
-          echo "${{ env.TEST_DATASET_MD5 }}  ${{ env.TEST_DATASET_ID }}.hic" > checksum.md5
+          curl -L '${{ env.TEST_DATASET_URL }}' -o '${{ env.TEST_DATASET_ID }}.mcool'
+          echo "${{ env.TEST_DATASET_MD5 }}  ${{ env.TEST_DATASET_ID }}.mcool" > checksum.md5
           md5sum -c checksum.md5
 
       - name: Save test dataset
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           key: ${{ env.TEST_DATASET_ID }}
-          path: ${{ env.TEST_DATASET_ID }}.hic
+          path: ${{ env.TEST_DATASET_ID }}.mcool
 
       - name: Generate build args
         id: build-args

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      TEST_DATASET_ID: 4DNFIOTPSS3L
+      TEST_DATASET_ID: 4DNFI9GMP2J8
 
     steps:
       - uses: actions/checkout@v4
@@ -101,7 +101,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: ${{ env.TEST_DATASET_ID }}
-          path: ${{ env.TEST_DATASET_ID }}.hic
+          path: ${{ env.TEST_DATASET_ID }}.mcool
 
       - name: Download test dataset
         if: steps.cache-dset.outputs.cache-hit != 'true'
@@ -112,15 +112,15 @@ jobs:
         uses: actions/cache/save@v4
         with:
           key: ${{ env.TEST_DATASET_ID }}
-          path: ${{ env.TEST_DATASET_ID }}.hic
+          path: ${{ env.TEST_DATASET_ID }}.mcool
 
       - name: Test stripepy call
         run: |
           NPROC="$(python -c 'import multiprocessing as mp; print(mp.cpu_count())')"
 
           stripepy call \
-            ${{ env.TEST_DATASET_ID }}.hic \
-            100000 \
+            ${{ env.TEST_DATASET_ID }}.mcool \
+            20000 \
             -o stripepy/ \
             --glob-pers-type constant \
             --glob-pers-min 0.10 \

--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -21,19 +21,40 @@ def _get_datasets(max_size: float) -> Dict[str, Dict[str, str]]:
     assert not math.isnan(max_size)
 
     datasets = {
-        "4DNFIOTPSS3L": {
-            "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/7386f953-8da9-47b0-acb2-931cba810544/4DNFIOTPSS3L.hic",
-            "md5": "d8b030bec6918bfbb8581c700990f49d",
-            "assembly": "dm6",
-            "format": "hic",
-            "size_mb": 248.10,
+        "4DNFI3RFZLZ5": {
+            "url": "https://zenodo.org/records/14283922/files/4DNFI3RFZLZ5.stripepy.mcool?download=1",
+            "md5": "f6e060211c95dd5fbf6e708c637d1c1c",
+            "assembly": "mm10",
+            "format": "mcool",
+            "size_mb": 83.85,
         },
         "4DNFIC1CLPK7": {
-            "url": "https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/0dc0b1ba-5509-4464-9814-dfe103ff09a0/4DNFIC1CLPK7.hic",
-            "md5": "9648c38d52fb467846cce42a4a072f57",
-            "assembly": "galGal5",
+            "url": "https://zenodo.org/records/14283922/files/4DNFI6HDY7WZ.stripepy.mcool?download=1",
+            "md5": "745df902a842c17e535222fb7f9748ca",
+            "assembly": "hg38",
+            "format": "mcool",
+            "size_mb": 104.73,
+        },
+        "4DNFI9GMP2J8": {
+            "url": "https://zenodo.org/records/14283922/files/4DNFI9GMP2J8.stripepy.mcool?download=1",
+            "md5": "a17d08460c03cf6c926e2ca5743e4888",
+            "assembly": "hg38",
+            "format": "mcool",
+            "size_mb": 106.84,
+        },
+        "ENCFF993FGR": {
+            "url": "https://zenodo.org/records/14283922/files/ENCFF993FGR.stripepy.hic?download=1",
+            "md5": "3bcb8c8c5aac237f26f994e0f5e983d7",
+            "assembly": "hg38",
             "format": "hic",
-            "size_mb": 583.57,
+            "size_mb": 185.29,
+        },
+        "__results_v1": {
+            "url": "https://zenodo.org/records/14283922/files/results_4DNFI9GMP2J8_v1.hdf5?download=1",
+            "md5": "632b2a7a6e5c1a24dc3635710ed68a80",
+            "assembly": "hg38",
+            "format": "stripepy",
+            "size_mb": 8.75,
         },
     }
 
@@ -46,7 +67,8 @@ def _get_datasets(max_size: float) -> Dict[str, Dict[str, str]]:
 
 
 def _list_datasets():
-    json.dump(_get_datasets(math.inf), fp=sys.stdout, indent=2)
+    dsets = {k: v for k, v in _get_datasets(math.inf).items() if not k.startswith("__")}
+    json.dump(dsets, fp=sys.stdout, indent=2)
     sys.stdout.write("\n")
 
 

--- a/utils/devel/test_docker_image.sh
+++ b/utils/devel/test_docker_image.sh
@@ -25,20 +25,20 @@ IMG="$1"
 tmpdir="$(mktemp -d)"
 trap "rm -rf '$tmpdir'" EXIT
 
-TEST_DATASET='4DNFIOTPSS3L'
-TEST_DATASET_URL='https://4dn-open-data-public.s3.amazonaws.com/fourfront-webprod/wfoutput/7386f953-8da9-47b0-acb2-931cba810544/4DNFIOTPSS3L.hic'
-TEST_DATASET_MD5='d8b030bec6918bfbb8581c700990f49d'
+TEST_DATASET='4DNFI9GMP2J8'
+TEST_DATASET_URL='https://zenodo.org/records/14283922/files/4DNFI9GMP2J8.stripepy.mcool?download=1'
+TEST_DATASET_MD5='a17d08460c03cf6c926e2ca5743e4888'
 
-if [ -f "$TEST_DATASET.hic" ]; then
+if [ -f "$TEST_DATASET.mcool" ]; then
   1>&2 echo "Copying test dataset to \"$tmpdir\"..."
-  cp "$TEST_DATASET.hic" "$tmpdir/$TEST_DATASET.hic"
+  cp "$TEST_DATASET.mcool" "$tmpdir/$TEST_DATASET.mcool"
 else
   1>&2 echo "Test dataset \"$TEST_DATASET\" not found"
   1>&2 echo "Downloading test dataset to \"$tmpdir\"..."
-  curl -L "$TEST_DATASET_URL" -o "$tmpdir/$TEST_DATASET.hic"
+  curl -L "$TEST_DATASET_URL" -o "$tmpdir/$TEST_DATASET.mcool"
 fi
 
-echo "$TEST_DATASET_MD5  $tmpdir/$TEST_DATASET.hic" > "$tmpdir/checksum.md5"
+echo "$TEST_DATASET_MD5  $tmpdir/$TEST_DATASET.mcool" > "$tmpdir/checksum.md5"
 md5sum -c "$tmpdir/checksum.md5"
 
 cat > "$tmpdir/runme.sh" <<- 'EOM'
@@ -55,7 +55,7 @@ TEST_DATASET="$1"
 
 stripepy call \
   "$TEST_DATASET" \
-  100000 \
+  20000 \
   -o stripepy/ \
   --glob-pers-type constant \
   --glob-pers-min 0.10 \
@@ -84,6 +84,6 @@ fi
 
 sudo -u "$DOCKER_USER" docker run --rm --entrypoint=/bin/bash \
   -v "$tmpdir/runme.sh:/tmp/runme.sh:ro" \
-  -v "$tmpdir/$TEST_DATASET.hic:/data/$TEST_DATASET.hic:ro" \
+  -v "$tmpdir/$TEST_DATASET.mcool:/data/$TEST_DATASET.mcool:ro" \
   "$IMG" \
-  /tmp/runme.sh "/data/$TEST_DATASET.hic"
+  /tmp/runme.sh "/data/$TEST_DATASET.mcool"


### PR DESCRIPTION
Update the tests datasets known to `stripepy download` and used by the CI with the datasets from [10.5281/zenodo.14283921](https://doi.org/10.5281/zenodo.14283921).

This was done with the following aims:
- Use more realistic datasets (e.g. mammalian Hi-C files instead of very sparse drosophila files)
- Reduce file size by not storing interactions that will never be used by StripePy (e.g. trans interactions and interactions very far away from the matrix diagonal)
- Have more control on the test datasets by hosting them ourselves.

We downloaded the datasets from the 4DNucleome Data portal and ENCODE.
Datasets were processed as follows:
- Convert all datasets to .mcool format using `hictk convert`
- Fix .mcool files downloaded from the 4DNucleome using `hictk fix-mcool`
- Minify the .mcool files using [test/scripts/generate_test_matrix.py](https://github.com/paulsengroup/StripePy/blob/main/test/scripts/generate_test_matrix.py)
- Generate the minified .hic files from the minified .mcool files using `hictk convert`

Closes https://github.com/paulsengroup/StripePy/issues/48.