### PR TITLE
Rename package from stripepy to stripepy-hic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
 build-backend = "hatchling.build"
 
 [project]
-name = "stripepy"
+name = "stripepy-hic"
 description = "StripePy recognizes architectural stripes in 3C and Hi-C contact maps using geometric reasoning"
 dynamic = ["version"]
 authors = [
@@ -70,11 +70,11 @@ dependencies = [
 test = [
     "pytest",
     "pytest-cov",
-    "stripepy",
+    "stripepy-hic",
 ]
 
 dev = [
-    "stripepy[test]",
+    "stripepy-hic[test]",
     "black[jupyter]",
     "build",
     "isort",

--- a/src/stripepy/IO.py
+++ b/src/stripepy/IO.py
@@ -545,7 +545,7 @@ class ResultFile(object):
         self._h5.attrs["format"] = "HDF5::StripePy"
         self._h5.attrs["format-url"] = "https://github.com/paulsengroup/StripePy"
         self._h5.attrs["format-version"] = 1
-        self._h5.attrs["generated-by"] = f"StripePy v{version('stripepy')}"
+        self._h5.attrs["generated-by"] = f"StripePy v{version('stripepy-hic')}"
         self._h5.attrs["metadata"] = json.dumps(metadata, indent=2)
         self._h5.attrs["normalization"] = normalization
 

--- a/src/stripepy/__init__.py
+++ b/src/stripepy/__init__.py
@@ -6,4 +6,4 @@ from importlib.metadata import version
 
 from .main import main
 
-__version__ = version("stripepy")
+__version__ = version("stripepy-hic")

--- a/src/stripepy/cli/setup.py
+++ b/src/stripepy/cli/setup.py
@@ -442,7 +442,7 @@ def _make_cli() -> argparse.ArgumentParser:
         "-v",
         "--version",
         action="version",
-        version="%(prog)s {version}".format(version=version("stripepy")),
+        version="%(prog)s {version}".format(version=version("stripepy-hic")),
     )
 
     return cli


### PR DESCRIPTION
The stripepy namespace is not available on PyPI.
There is no actual package with this name, but I suspect the package name has been parked by Stripe Inc. to avoid name confusion when installing their Python API: https://github.com/stripe/stripe-python

Beside the package name, nothing has changed: the entrypoint for the CLI is still called `stripepy` and all library code resides under the `stripepy` namespace.