### PR TITLE
[dependencies] remove unused dependency and reduce number of core dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install package
-        run: pip install --verbose '.[test]'
+        run: pip install --verbose '.[all,test]'
 
       - name: Run simple CLI tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,13 +88,39 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - name: Install package
-        run: pip install --verbose '.[all,test]'
+      - name: Install package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          python -m venv venv
+          python -m venv venv-core
+
+          venv/bin/pip install '.[all,test]'
+          venv-core/bin/pip install '.' pytest pytest-cov
+
+          echo "STRIPEPY_ROOT=venv/bin" >> "$GITHUB_ENV"
+          echo "STRIPEPY_CORE_ROOT=venv-core/bin" >> "$GITHUB_ENV"
+
+      - name: Install package (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          python -m venv venv
+          python -m venv venv-core
+
+          venv/Scripts/pip install '.[all,test]'
+          venv-core/Scripts/pip install '.' pytest pytest-cov
+
+          echo "STRIPEPY_ROOT=venv/Scripts" >> "$GITHUB_ENV"
+          echo "STRIPEPY_CORE_ROOT=venv-core/Scripts" >> "$GITHUB_ENV"
 
       - name: Run simple CLI tests
         run: |
-          stripepy --help
-          stripepy --version
+          "$STRIPEPY_ROOT/stripepy" --help
+          "$STRIPEPY_ROOT/stripepy" --version
+
+      - name: Run simple CLI tests (core)
+        run: |
+          "$STRIPEPY_CORE_ROOT/stripepy" --help
+          "$STRIPEPY_CORE_ROOT/stripepy" --version
 
       - name: Restore test dataset
         uses: actions/cache/restore@v4
@@ -106,7 +132,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          python -m pytest \
+          "$STRIPEPY_ROOT/python" -m pytest \
             --cov=stripepy \
             --verbose \
             --cov-report=xml \
@@ -124,11 +150,33 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
+      - name: Run unit tests (core)
+        run: |
+          rm -f coverage.xml
+
+          "$STRIPEPY_CORE_ROOT/python" -m pytest \
+            --cov=stripepy \
+            --verbose \
+            --cov-report=xml \
+            --cov-report=term \
+            test/ \
+            -m unit
+
+      - name: Upload unit test coverage report to Codecov (core)
+        uses: codecov/codecov-action@v5
+        with:
+          flags: "tests | unit | python-${{ matrix.python_version }} | core"
+          disable_search: true
+          files: coverage.xml
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
       - name: Run integration tests
         run: |
           rm -f coverage.xml
 
-          python -m pytest \
+          "$STRIPEPY_ROOT/python" -m pytest \
             --cov=stripepy \
             --verbose \
             --cov-report=xml \
@@ -140,6 +188,28 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           flags: "tests | integration | python-${{ matrix.python_version }}"
+          disable_search: true
+          files: coverage.xml
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Run integration tests (core)
+        run: |
+          rm -f coverage.xml
+
+          "$STRIPEPY_CORE_ROOT/python" -m pytest \
+            --cov=stripepy \
+            --verbose \
+            --cov-report=xml \
+            --cov-report=term \
+            test/ \
+            -m end2end
+
+      - name: Upload end2end test coverage report to Codecov (core)
+        uses: codecov/codecov-action@v5
+        with:
+          flags: "tests | integration | python-${{ matrix.python_version }} | core"
           disable_search: true
           files: coverage.xml
           fail_ci_if_error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ARG install_dir='/opt/stripepy'
 COPY . "$src_dir/"
 
 RUN python3 -m venv "$install_dir" \
-&& "$install_dir/bin/pip" install "$src_dir" -v --no-compile
+&& "$install_dir/bin/pip" install "$src_dir[all]" -v --no-compile
 
 
 ARG BASE_IMAGE

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ StripePy is developed on Linux and macOS and is also tested on Windows.
 ### Installing with pip
 
 ```bash
-pip install stripepy-hic
+pip install 'stripepy-hic[all]'
 ```
 
 ### Installing with conda
@@ -50,7 +50,7 @@ git clone https://github.com/paulsengroup/StripePy.git
 
 # install StripePy
 cd StripePy
-pip install .
+pip install '.[all]'
 
 # ensure StripePy is in your PATH
 stripepy --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ requires-python = ">=3.9"
 dependencies = [
     "h5py >3, <4",
     "hictkpy[scipy] >=1, <2",
-    "matplotlib >=3.8, <4",
     "numpy >=2, <3",
     "pandas >=2.0, <3",
     "scipy >=1.10, <2",
@@ -70,6 +69,7 @@ all = [
     "stripepy-hic",
     "alive-progress >=3.2, <4",
     "colorama >=0.4, <0.5",
+    "matplotlib >=3.8, <4",
     "rich >=13.9, <14",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ keywords = [
 requires-python = ">=3.9"
 dependencies = [
     "alive-progress >=3.2, <4",
-    "colorama >=0.4, <0.5",
     "h5py >3, <4",
     "hictkpy[scipy] >=1, <2",
     "matplotlib >=3.8, <4",
@@ -70,6 +69,7 @@ dependencies = [
 
 all = [
     "stripepy-hic",
+    "colorama >=0.4, <0.5",
     "rich >=13.9, <14",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,21 +62,25 @@ dependencies = [
     "matplotlib >=3.8, <4",
     "numpy >=2, <3",
     "pandas >=2.0, <3",
-    "rich >=13.9, <14",
     "scipy >=1.10, <2",
     "structlog >=24, <25"
 ]
 
 [project.optional-dependencies]
 
+all = [
+    "stripepy-hic",
+    "rich >=13.9, <14",
+]
+
 test = [
+    "stripepy-hic[all]",
     "pytest",
     "pytest-cov",
-    "stripepy-hic",
 ]
 
 dev = [
-    "stripepy-hic[test]",
+    "stripepy-hic[all,test]",
     "black[jupyter]",
     "build",
     "isort",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ keywords = [
 
 requires-python = ">=3.9"
 dependencies = [
-    "alive-progress >=3.2, <4",
     "h5py >3, <4",
     "hictkpy[scipy] >=1, <2",
     "matplotlib >=3.8, <4",
@@ -69,6 +68,7 @@ dependencies = [
 
 all = [
     "stripepy-hic",
+    "alive-progress >=3.2, <4",
     "colorama >=0.4, <0.5",
     "rich >=13.9, <14",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,7 @@ dependencies = [
     "numpy >=2, <3",
     "pandas >=2.0, <3",
     "rich >=13.9, <14",
-    "scikit-learn >=1.5, <2",
     "scipy >=1.10, <2",
-    "seaborn >=0.13, <1",
     "structlog >=24, <25"
 ]
 

--- a/src/stripepy/cli/call.py
+++ b/src/stripepy/cli/call.py
@@ -10,13 +10,13 @@ import sys
 import time
 from typing import Any, Dict, List, Tuple
 
-import alive_progress as ap
 import numpy as np
 import pandas as pd
 import structlog
 
 from stripepy import IO, others, stripepy
 from stripepy.utils.common import pretty_format_elapsed_time
+from stripepy.utils.progress_bar import initialize_progress_bar
 
 
 def _generate_metadata_attribute(configs_input: Dict[str, Any], configs_thresholds: Dict[str, Any]) -> Dict[str, Any]:
@@ -172,7 +172,7 @@ def run(
             f.chromosomes(), include_plotting=configs_input["roi"] is not None, nproc=configs_other["nproc"]
         )
         progress_bar = ctx.enter_context(
-            ap.alive_bar(
+            initialize_progress_bar(
                 total=sum(f.chromosomes().values()),
                 manual=True,
                 disable=disable_bar,

--- a/src/stripepy/cli/call.py
+++ b/src/stripepy/cli/call.py
@@ -54,7 +54,7 @@ def _plan(chromosomes: Dict[str, int], min_size: int, logger=None) -> List[Tuple
 
 
 def _generate_empty_result(chrom: str, chrom_size: int, resolution: int) -> IO.Result:
-    result = IO.Result(chrom)
+    result = IO.Result(chrom, chrom_size)
     result.set_min_persistence(0)
 
     num_bins = (chrom_size + resolution - 1) // resolution

--- a/src/stripepy/cli/call.py
+++ b/src/stripepy/cli/call.py
@@ -148,11 +148,7 @@ def run(
 
     if configs_input["roi"] is not None:
         # Raise an error immediately if --roi was passed and matplotlib is not available
-        try:
-            _import_matplotlib()
-        except ImportError as e:
-            structlog.get_logger().error(e)
-            raise
+        _import_matplotlib()
 
     # Data loading:
     f = others.open_matrix_file_checked(configs_input["contact_map"], configs_input["resolution"])

--- a/src/stripepy/cli/call.py
+++ b/src/stripepy/cli/call.py
@@ -140,7 +140,7 @@ def run(
     configs_thresholds: Dict[str, Any],
     configs_output: Dict[str, Any],
     configs_other: Dict[str, Any],
-):
+) -> int:
     # How long does stripepy take to analyze the whole Hi-C matrix?
     start_global_time = time.time()
 
@@ -337,3 +337,5 @@ def run(
     main_logger.info(
         "processed %d chromosomes in %s", len(f.chromosomes()), pretty_format_elapsed_time(start_global_time)
     )
+
+    return 0

--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -269,15 +269,15 @@ def run(
     t0 = time.time()
     if list_only:
         _list_datasets()
-        return
+        return 0
 
     if unit_test:
         _download_data_for_unit_tests()
-        return
+        return 0
 
     if end2end_test:
         _download_data_for_end2end_tests()
-        return
+        return 0
 
     do_random_sample = name is None and assembly is None
 

--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -14,10 +14,10 @@ import time
 import urllib.request
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
-import alive_progress as ap
 import structlog
 
 from stripepy.utils.common import pretty_format_elapsed_time
+from stripepy.utils.progress_bar import initialize_progress_bar
 
 
 @functools.cache
@@ -130,7 +130,7 @@ def _hash_file(path: pathlib.Path, chunk_size=16 << 20) -> str:
     file_size = path.stat().st_size
     disable_bar = not sys.stderr.isatty() or file_size < (256 << 20)
 
-    with ap.alive_bar(
+    with initialize_progress_bar(
         total=file_size,
         disable=disable_bar,
         enrich_print=False,
@@ -185,7 +185,7 @@ def _download_and_checksum(name: str, dset: Dict[str, Any], dest: pathlib.Path):
 
         disable_bar = not sys.stderr.isatty() or size is None
 
-        with ap.alive_bar(
+        with initialize_progress_bar(
             total=size,
             manual=True,
             disable=disable_bar,

--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -265,7 +265,7 @@ def run(
     unit_test: bool,
     end2end_test: bool,
     force: bool,
-):
+) -> int:
     t0 = time.time()
     if list_only:
         _list_datasets()
@@ -303,3 +303,5 @@ def run(
     logger.info(
         f"file size: %.2fMB. Elapsed time: %s", dest.stat().st_size / (1024 << 10), pretty_format_elapsed_time(t0)
     )
+
+    return 0

--- a/src/stripepy/cli/plot.py
+++ b/src/stripepy/cli/plot.py
@@ -329,11 +329,7 @@ def run(plot_type: str, output_name: pathlib.Path, dpi: int, force: bool, **kwar
     t0 = time.time()
 
     # Raise an error immediately if matplotlib is not available
-    try:
-        _import_matplotlib()
-    except ImportError as e:
-        logger.error(e)
-        raise
+    _import_matplotlib()
 
     if output_name.exists():
         if force:

--- a/src/stripepy/cli/plot.py
+++ b/src/stripepy/cli/plot.py
@@ -324,7 +324,13 @@ def _plot_stripe_dimension_distribution(
     return fig
 
 
-def run(plot_type: str, output_name: pathlib.Path, dpi: int, force: bool, **kwargs):
+def run(
+    plot_type: str,
+    output_name: pathlib.Path,
+    dpi: int,
+    force: bool,
+    **kwargs,
+) -> int:
     logger = structlog.get_logger()
     t0 = time.time()
 
@@ -374,3 +380,5 @@ def run(plot_type: str, output_name: pathlib.Path, dpi: int, force: bool, **kwar
 
     logger.info("DONE!")
     logger.info("plotting took %s seconds", pretty_format_elapsed_time(t0))
+
+    return 0

--- a/src/stripepy/cli/plot.py
+++ b/src/stripepy/cli/plot.py
@@ -8,14 +8,20 @@ import time
 from typing import Dict, Optional, Tuple
 
 import hictkpy
-import matplotlib.pyplot as plt
 import numpy as np
 import structlog
 from numpy.typing import NDArray
 
 import stripepy.plot
 from stripepy.IO import Result, ResultFile
-from stripepy.utils.common import pretty_format_elapsed_time
+from stripepy.utils.common import _import_matplotlib, pretty_format_elapsed_time
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    from stripepy.utils.common import _DummyPyplot
+
+    plt = _DummyPyplot()
 
 
 def _generate_random_region(
@@ -321,6 +327,13 @@ def _plot_stripe_dimension_distribution(
 def run(plot_type: str, output_name: pathlib.Path, dpi: int, force: bool, **kwargs):
     logger = structlog.get_logger()
     t0 = time.time()
+
+    # Raise an error immediately if matplotlib is not available
+    try:
+        _import_matplotlib()
+    except ImportError as e:
+        logger.error(e)
+        raise
 
     if output_name.exists():
         if force:

--- a/src/stripepy/cli/view.py
+++ b/src/stripepy/cli/view.py
@@ -91,7 +91,9 @@ def run(
     h5_file: pathlib.Path,
     relative_change_threshold: float,
     transform: Union[str, None],
-):
+) -> int:
     with ResultFile(h5_file) as f:
         for chrom, size in f.chromosomes.items():
             _dump_stripes(f, chrom, size, f.resolution, relative_change_threshold, transform)
+
+    return 0

--- a/src/stripepy/main.py
+++ b/src/stripepy/main.py
@@ -335,10 +335,9 @@ def main(args: Union[List[str], None] = None):
         raise NotImplementedError
 
     except (RuntimeError, ImportError) as e:
-        logger = structlog.get_logger()
-        logger.exception(e)
-        sys.exit(1)
+        structlog.get_logger().exception(e)
+        return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/stripepy/main.py
+++ b/src/stripepy/main.py
@@ -336,6 +336,8 @@ def main(args: Union[List[str], None] = None):
 
     except (RuntimeError, ImportError) as e:
         structlog.get_logger().exception(e)
+        if args is not None:
+            raise
         return 1
 
 

--- a/src/stripepy/main.py
+++ b/src/stripepy/main.py
@@ -334,7 +334,7 @@ def main(args: Union[List[str], None] = None):
 
         raise NotImplementedError
 
-    except RuntimeError as e:
+    except (RuntimeError, ImportError) as e:
         logger = structlog.get_logger()
         logger.exception(e)
         sys.exit(1)

--- a/src/stripepy/main.py
+++ b/src/stripepy/main.py
@@ -22,8 +22,12 @@ def _setup_matplotlib(subcommand: str, **kwargs):
     if subcommand == "call" and kwargs["configs_input"]["roi"] is None:
         return
 
-    import matplotlib
-    import matplotlib.pyplot as plt
+    try:
+        import matplotlib
+        import matplotlib.pyplot as plt
+    except ImportError:
+        structlog.get_logger().warning("failed to configure matplotlib")
+        return
 
     # This is very important, as some plotting operations are performed concurrently
     # using multiprocessing.

--- a/src/stripepy/main.py
+++ b/src/stripepy/main.py
@@ -310,7 +310,7 @@ def main(args: Union[List[str], None] = None):
 
         raise NotImplementedError
 
-    except Exception as e:
+    except RuntimeError as e:
         logger = structlog.get_logger()
         logger.exception(e)
         sys.exit(1)

--- a/src/stripepy/main.py
+++ b/src/stripepy/main.py
@@ -36,26 +36,27 @@ def _setup_matplotlib(subcommand: str, **kwargs):
     plt.set_loglevel(level="warning")
 
 
-class _StructLogPlainStyles:
-    reset = ""
-    bright = ""
-    dim = ""
+class _StructLogPlainStyles(object):
+    def __init__(self):
+        self.reset = ""
+        self.bright = ""
+        self.dim = ""
 
-    level_critical = ""
-    level_exception = ""
-    level_error = ""
-    level_warn = ""
-    level_info = ""
-    level_debug = ""
-    level_notset = ""
+        self.level_critical = ""
+        self.level_exception = ""
+        self.level_error = ""
+        self.level_warn = ""
+        self.level_info = ""
+        self.level_debug = ""
+        self.level_notset = ""
 
-    timestamp = ""
-    chromosome = ""
-    step = ""
-    logger_name = ""
+        self.timestamp = ""
+        self.chromosome = ""
+        self.step = ""
+        self.logger_name = ""
 
 
-class _StructLogColorfulStyles:
+class _StructLogColorfulStyles(object):
     @staticmethod
     def _try_get_color(key: str):
         try:
@@ -65,22 +66,24 @@ class _StructLogColorfulStyles:
         except ImportError:
             return ""
 
-    reset = _try_get_color("Style.RESET_ALL")
-    bright = _try_get_color("Style.BRIGHT")
-    dim = _try_get_color("Style.DIM")
+    def __init__(self):
+        _try_get_color = _StructLogColorfulStyles._try_get_color
+        self.reset = _try_get_color("Style.RESET_ALL")
+        self.bright = _try_get_color("Style.BRIGHT")
+        self.dim = _try_get_color("Style.DIM")
 
-    level_critical = _try_get_color("Fore.RED")
-    level_exception = _try_get_color("Fore.RED")
-    level_error = _try_get_color("Fore.RED")
-    level_warn = _try_get_color("Fore.YELLOW")
-    level_info = _try_get_color("Fore.GREEN")
-    level_debug = _try_get_color("Fore.GREEN")
-    level_notset = _try_get_color("Back.RED")
+        self.level_critical = _try_get_color("Fore.RED")
+        self.level_exception = _try_get_color("Fore.RED")
+        self.level_error = _try_get_color("Fore.RED")
+        self.level_warn = _try_get_color("Fore.YELLOW")
+        self.level_info = _try_get_color("Fore.GREEN")
+        self.level_debug = _try_get_color("Fore.GREEN")
+        self.level_notset = _try_get_color("Back.RED")
 
-    timestamp = dim
-    chromosome = _try_get_color("Fore.BLUE")
-    step = _try_get_color("Fore.BLUE")
-    logger_name = _try_get_color("Fore.BLUE")
+        self.timestamp = self.dim
+        self.chromosome = _try_get_color("Fore.BLUE")
+        self.step = _try_get_color("Fore.BLUE")
+        self.logger_name = _try_get_color("Fore.BLUE")
 
 
 def _configure_logger_columns(
@@ -125,9 +128,9 @@ def _configure_logger_columns(
 
             colorama.init()
 
-        styles = _StructLogColorfulStyles
+        styles = _StructLogColorfulStyles()
     else:
-        styles = _StructLogPlainStyles
+        styles = _StructLogPlainStyles()
 
     def step_formatter(data):
         if isinstance(data, collections.abc.Sequence):

--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -8,7 +8,6 @@ import time
 from typing import Dict, List, Optional, Tuple
 
 import h5py
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import scipy.sparse as ss
@@ -500,6 +499,7 @@ def _plot_pseudodistribution(
     output_folder: pathlib.Path,
     logger,
 ):
+    plt = common._import_pyplot()
     assert result.roi is not None
 
     logger.bind(step=(5, 1, 1)).info("plotting pseudo-distributions")
@@ -539,6 +539,7 @@ def _plot_hic_and_hois(
     output_folder: pathlib.Path,
     logger,
 ):
+    plt = common._import_pyplot()
     assert result.roi is not None
 
     if matrix is None:
@@ -576,6 +577,7 @@ def _plot_geo_descriptors(
     output_folder: pathlib.Path,
     logger,
 ):
+    plt = common._import_pyplot()
     logger.bind(step=(5, 3, 1)).info("generating histograms for geo-descriptors")
     fig, _ = plot.plot(result, resolution, plot_type="geo_descriptors", start=0, end=result.chrom[1])
     fig.savefig(output_folder / "geo_descriptors.jpg", dpi=256)
@@ -619,7 +621,7 @@ def _plot_local_pseudodistributions_helper(args):
         location,
         logger,
     ) = args
-
+    plt = common._import_pyplot()
     logger.bind(step=(5, 4, i)).debug("plotting local profile for seed %d (%s)", seed, location)
 
     if location == "LT":
@@ -733,6 +735,7 @@ def _plot_local_pseudodistributions(
 
 
 def _plot_stripes_helper(args):
+    plt = common._import_pyplot()
     matrix, result, resolution, start, end, cutoff, output_folder, logger = args
     logger.debug("plotting stripes with cutoff=%.2f", cutoff)
 
@@ -820,6 +823,8 @@ def step_5(
 ):
     if result.roi is None:
         return
+
+    plt = common._import_pyplot()
 
     if logger is None:
         logger = structlog.get_logger()

--- a/src/stripepy/utils/common.py
+++ b/src/stripepy/utils/common.py
@@ -69,3 +69,37 @@ def pretty_format_elapsed_time(t0: float, t1: Optional[float] = None) -> str:
     minutes = (delta - (hours * 3600)) // 60
     seconds = delta - (hours * 3600) - (minutes * 60)
     return f"{hours:.0f}h:{minutes:.0f}m:{seconds:.3f}s"
+
+
+def _import_matplotlib():
+    """
+    Helper function to import matplotlib.
+    """
+    try:
+        import matplotlib
+
+        return matplotlib
+    except ImportError as e:
+        raise ImportError(
+            "To enable matplotlib support, please install StripePy with: pip install 'stripepy-hic[all]'"
+        ) from e
+
+
+def _import_pyplot():
+    """
+    Helper function to import matplotlib.pyplot.
+    """
+    _import_matplotlib()
+    import matplotlib.pyplot as plt
+
+    return plt
+
+
+class _DummyPyplot(object):
+    """
+    class to mock common types from matplotlib.pyplot.
+    """
+
+    def __init__(self):
+        self.Figure = None
+        self.Axes = None

--- a/src/stripepy/utils/common.py
+++ b/src/stripepy/utils/common.py
@@ -81,7 +81,7 @@ def _import_matplotlib():
         return matplotlib
     except ImportError as e:
         raise ImportError(
-            "Unable to import matplotlib: to enable matplotlib support, please install StripePy with: pip install 'stripepy-hic[all]'"
+            "unable to import matplotlib: to enable matplotlib support, please install StripePy with: pip install 'stripepy-hic[all]'"
         ) from e
 
 

--- a/src/stripepy/utils/common.py
+++ b/src/stripepy/utils/common.py
@@ -81,7 +81,7 @@ def _import_matplotlib():
         return matplotlib
     except ImportError as e:
         raise ImportError(
-            "To enable matplotlib support, please install StripePy with: pip install 'stripepy-hic[all]'"
+            "Unable to import matplotlib: to enable matplotlib support, please install StripePy with: pip install 'stripepy-hic[all]'"
         ) from e
 
 

--- a/src/stripepy/utils/progress_bar.py
+++ b/src/stripepy/utils/progress_bar.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2025 Roberto Rossini <roberroso@uio.no>
+#
+# SPDX-License-Identifier: MIT
+
+
+class _DummyProgressBar(object):
+    """
+    A progress bar class that does nothing.
+    """
+
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        def callable(*args, **kwargs):
+            pass
+
+        return callable
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+def initialize_progress_bar(*args, **kwargs):
+    """
+    Attempt to initialize a progress bar using alive_progress.
+    In case of failure, return a dummy progress bar that does nothing.
+    """
+    try:
+        import alive_progress
+
+        return alive_progress.alive_bar(*args, **kwargs)
+    except ImportError:
+        return _DummyProgressBar()

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Roberto Rossini <roberroso@uio.no>
+#
+# SPDX-License-Identifier: MIT

--- a/test/integration/common.py
+++ b/test/integration/common.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2025 Roberto Rossini <roberroso@uio.no>
+#
+# SPDX-License-Identifier: MIT
+
+
+def matplotlib_avail() -> bool:
+    try:
+        import matplotlib
+    except ImportError:
+        return False
+
+    return True

--- a/test/integration/test_stripepy_call.py
+++ b/test/integration/test_stripepy_call.py
@@ -35,6 +35,9 @@ class TestStripePyCall:
         testfile = testdir / "data" / "4DNFI9GMP2J8.mcool"
         resolution = 10_000
 
+        chrom_sizes = hictkpy.MultiResFile(testfile).chromosomes()
+        chrom_size_cutoff = sum(chrom_sizes.values()) // len(chrom_sizes)
+
         args = [
             "call",
             str(testfile),
@@ -47,6 +50,8 @@ class TestStripePyCall:
             "0.25",
             "--output-folder",
             str(tmpdir),
+            "--min-chrom-size",
+            str(chrom_size_cutoff),
         ]
         main(args)
 

--- a/test/integration/test_stripepy_call.py
+++ b/test/integration/test_stripepy_call.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import pathlib
+import warnings
 
 import h5py
 import hictkpy
@@ -83,7 +84,9 @@ class TestStripePyCall:
                 main(args)
             pytest.skip("matplotlib not available")
 
-        main(args)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning)
+            main(args)
 
         outfile = pathlib.Path(tmpdir) / testfile.stem / str(resolution) / "results.hdf5"
 

--- a/test/integration/test_stripepy_call.py
+++ b/test/integration/test_stripepy_call.py
@@ -5,9 +5,12 @@
 import pathlib
 
 import h5py
+import hictkpy
 import pytest
 
 from stripepy import main
+
+from .common import matplotlib_avail
 
 testdir = pathlib.Path(__file__).resolve().parent.parent
 
@@ -44,6 +47,42 @@ class TestStripePyCall:
             "--output-folder",
             str(tmpdir),
         ]
+        main(args)
+
+        outfile = pathlib.Path(tmpdir) / testfile.stem / str(resolution) / "results.hdf5"
+
+        assert outfile.is_file()
+        assert h5py.File(outfile).attrs.get("format", "unknown") == "HDF5::StripePy"
+
+    @staticmethod
+    def test_stripepy_call_with_roi(tmpdir):
+        testfile = testdir / "data" / "4DNFI9GMP2J8.mcool"
+        resolution = 10_000
+
+        chrom_size_cutoff = max(hictkpy.MultiResFile(testfile).chromosomes().values()) - 1
+
+        args = [
+            "call",
+            str(testfile),
+            str(resolution),
+            "--glob-pers-min",
+            "0.10",
+            "--loc-pers-min",
+            "0.33",
+            "--loc-trend-min",
+            "0.25",
+            "--output-folder",
+            str(tmpdir),
+            "--min-chrom-size",
+            str(chrom_size_cutoff),
+            "--roi",
+            "middle",
+        ]
+        if not matplotlib_avail():
+            with pytest.raises(ImportError):
+                main(args)
+            pytest.skip("matplotlib not available")
+
         main(args)
 
         outfile = pathlib.Path(tmpdir) / testfile.stem / str(resolution) / "results.hdf5"

--- a/test/integration/test_stripepy_plot.py
+++ b/test/integration/test_stripepy_plot.py
@@ -10,6 +10,8 @@ import pytest
 
 from stripepy import main
 
+from .common import matplotlib_avail
+
 testdir = pathlib.Path(__file__).resolve().parent.parent
 
 
@@ -30,6 +32,17 @@ def extract_image(
             shutil.copyfileobj(fin, fout)  # noqa
 
     return dest_dir / name
+
+
+def run_main(args):
+    if matplotlib_avail():
+        main(args)
+        return
+
+    with pytest.raises(ImportError):
+        main(args)
+
+    pytest.skip("matplotlib not available")
 
 
 @pytest.mark.end2end
@@ -60,7 +73,7 @@ class TestStripePyPlot:
 
         outfile = tmpdir / "img.png"
         args = ["plot", "contact-map", str(matrix_file), str(resolution), str(outfile), "--region", region]
-        main(args)
+        run_main(args)
 
         assert outfile.is_file()
         compare_images(expected, outfile)
@@ -89,7 +102,7 @@ class TestStripePyPlot:
             "--region",
             region,
         ]
-        main(args)
+        run_main(args)
 
         assert outfile.is_file()
         compare_images(expected, outfile)
@@ -118,7 +131,7 @@ class TestStripePyPlot:
             "--region",
             region,
         ]
-        main(args)
+        run_main(args)
 
         assert outfile.is_file()
         compare_images(expected, outfile)
@@ -148,7 +161,7 @@ class TestStripePyPlot:
             "--region",
             region,
         ]
-        main(args)
+        run_main(args)
 
         assert outfile.is_file()
         compare_images(expected, outfile)
@@ -164,7 +177,7 @@ class TestStripePyPlot:
 
         outfile = tmpdir / "img.png"
         args = ["plot", "pseudodistribution", str(stripe_file), str(outfile), "--region", region]
-        main(args)
+        run_main(args)
 
         assert outfile.is_file()
         compare_images(expected, outfile)
@@ -180,7 +193,7 @@ class TestStripePyPlot:
 
         outfile = tmpdir / "img.png"
         args = ["plot", "stripe-hist", str(stripe_file), str(outfile), "--region", region]
-        main(args)
+        run_main(args)
 
         assert outfile.is_file()
         compare_images(expected, outfile)
@@ -194,7 +207,7 @@ class TestStripePyPlot:
 
         outfile = tmpdir / "img.png"
         args = ["plot", "stripe-hist", str(stripe_file), str(outfile)]
-        main(args)
+        run_main(args)
 
         assert outfile.is_file()
         compare_images(expected, outfile)


### PR DESCRIPTION
Drop `seaborn` and `scikit-learn`, as they are no longer needed.

StripePy recently picked up several dependencies that are nice-to-have, but that are not strictly needed to call stripes using `stripepy call`.
These dependencies have been made optional, such that users are not prevented from installing StripePy in case there are problems with one of these dependencies.

matplotlib is used throughout the codebase to generate plots.
However, `stripepy call` and `stripepy view` do not require matplotlib (or at least this is the case when `stripepy call` is run without specifying `--roi=*`).
Thus, I restructured import statements such that we import matplotlib only when strictly needed.

When running code that requires `matplotlib` and we are unable to import the module, an error like the following is generated:

```
2025-01-08 17:37:30.116596 [warning  ] failed to configure matplotlib
2025-01-08 17:37:30.125506 [info     ] CONFIG:
{
  "constrain_heights": false,
  "contact_map": "test/data/4DNFI9GMP2J8.mcool",
  "force": true,
  "genomic_belt": 5000000,
  "glob_pers_min": 0.05,
  "loc_pers_min": 0.33,
  "loc_trend_min": 0.25,
  "max_width": 100000,
  "min_chrom_size": 2000000,
  "normalization": null,
  "nproc": 1,
  "output_folder": "/tmp/stripepy-devel/4DNFI9GMP2J8/10000",
  "resolution": 10000,
  "roi": "middle"
}
2025-01-08 17:37:30.125653 [error    ] Unable to import matplotlib: to enable matplotlib support, please install StripePy with: pip install 'stripepy-hic[all]'
Traceback (most recent call last):
  File "/tmp/StripePy/venv/lib64/python3.13/site-packages/stripepy/utils/common.py", line 79, in _import_matplotlib
    import matplotlib
ModuleNotFoundError: No module named 'matplotlib'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tmp/StripePy/venv/bin/stripepy", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/tmp/StripePy/venv/lib64/python3.13/site-packages/stripepy/main.py", line 322, in main
    return call.run(**args)
           ~~~~~~~~^^^^^^^^
  File "/tmp/StripePy/venv/lib64/python3.13/site-packages/stripepy/cli/call.py", line 152, in run
    _import_matplotlib()
    ~~~~~~~~~~~~~~~~~~^^
  File "/tmp/StripePy/venv/lib64/python3.13/site-packages/stripepy/utils/common.py", line 82, in _import_matplotlib
    raise ImportError("Unable to import matplotlib: to enable matplotlib support, please install StripePy with: pip install 'stripepy-hic[all]'") from e
ImportError: Unable to import matplotlib: to enable matplotlib support, please install StripePy with: pip install 'stripepy-hic[all]'
```

In contrast, when one of the nice-to-have dependency cannot be imported, no error is emitted.
For example, if `colorama` is not available, the logger is configured to output message in plain text without colors.

Closes https://github.com/paulsengroup/StripePy/issues/74.