### PR TITLE
[performance]: optimize find_HIoIs()

### DIFF
--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -419,7 +419,6 @@ def step_3(
         seed_sites=LT_MPs,
         seed_site_bounds=LT_bounded_mPs,
         max_width=int(max_width / (2 * resolution)) + 1,
-        map_=map,
         logger=logger,
     )
     UT_HIoIs = finders.find_HIoIs(
@@ -427,7 +426,6 @@ def step_3(
         seed_sites=UT_MPs,
         seed_site_bounds=UT_bounded_mPs,
         max_width=int(max_width / (2 * resolution)) + 1,
-        map_=map,
         logger=logger,
     )
 

--- a/src/stripepy/utils/finders.py
+++ b/src/stripepy/utils/finders.py
@@ -20,7 +20,7 @@ from .regressions import _compute_wQISA_predictions
 
 def find_horizontal_domain(
     profile: npt.NDArray[float],
-    coarse_h_domain: Tuple[int, int, int],
+    params: Tuple[int, int, int, float],
     max_width: int = 1e9,
 ) -> Tuple[int, int]:
     """
@@ -31,14 +31,14 @@ def find_horizontal_domain(
     """
 
     # Unpacking:
-    MP, L_mP, R_mP = coarse_h_domain
+    MP, L_mP, R_mP, max_profile_value = params
 
     # Left and sides of candidate:
     L_interval = np.flip(profile[L_mP : MP + 1])
     R_interval = profile[MP : R_mP + 1]
 
     # LEFT INTERVAL
-    L_interval_shifted = np.append(L_interval[1:], [max(profile) + 1], axis=0)
+    L_interval_shifted = np.append(L_interval[1:], [max_profile_value + 1], axis=0)
     L_bound = np.where(L_interval - L_interval_shifted < 0)[0][0] + 1
     # L_interval_restr = L_interval[:L_bound]
     # L_interval_shifted_restr = L_interval_shifted[:L_bound]
@@ -46,7 +46,7 @@ def find_horizontal_domain(
     L_bound = np.minimum(L_bound, max_width)
 
     # RIGHT INTERVAL
-    R_interval_shifted = np.append(R_interval[1:], [max(profile) + 1], axis=0)
+    R_interval_shifted = np.append(R_interval[1:], [max_profile_value + 1], axis=0)
     R_bound = np.where(R_interval - R_interval_shifted < 0)[0][0] + 1
     # R_interval_restr = R_interval[:R_bound]
     # R_interval_shifted_restr = R_interval_shifted[:R_bound]
@@ -157,8 +157,9 @@ def find_HIoIs(
     if logger is None:
         logger = structlog.get_logger()
 
+    max_pseudodistribution_value = pseudodistribution.max()
     params = (
-        (seed_site, seed_site_bounds[num_MP], seed_site_bounds[num_MP + 1])
+        (seed_site, seed_site_bounds[num_MP], seed_site_bounds[num_MP + 1], max_pseudodistribution_value)
         for num_MP, seed_site in enumerate(seed_sites)
     )
 

--- a/src/stripepy/utils/finders.py
+++ b/src/stripepy/utils/finders.py
@@ -136,7 +136,6 @@ def find_HIoIs(
     seed_sites: npt.NDArray[int],
     seed_site_bounds: npt.NDArray[int],
     max_width: int,
-    map_=map,
     logger=None,
 ) -> pd.DataFrame:
     """
@@ -147,7 +146,6 @@ def find_HIoIs(
                                 (*) seed_site_bounds[i] is the left boundary
                                 (*) seed_site_bounds[i+1] is the right boundary
     :param max_width:           maximum width allowed
-    :param map_:                 alternative implementation of the built-in map function. Can be used to e.g. run this step in parallel by passing multiprocessing.Pool().map.
     :return:
     HIoIs                       a pd.DataFrame the list of left and right boundary for each seed site
     """
@@ -163,7 +161,7 @@ def find_HIoIs(
         for num_MP, seed_site in enumerate(seed_sites)
     )
 
-    tasks = map_(partial(find_horizontal_domain, pseudodistribution, max_width=max_width), params)
+    tasks = map(partial(find_horizontal_domain, pseudodistribution, max_width=max_width), params)
     # This efficiently constructs a 2D numpy with shape (N, 2) from a list of 2-element tuples, where N is the number of seed sites.
     # The first and second columns contains the left and right boundaries of the horizontal domains, respectively.
     HIoIs = np.fromiter(itertools.chain.from_iterable(tasks), count=2 * len(seed_sites), dtype=int).reshape(-1, 2)

--- a/src/stripepy/utils/finders.py
+++ b/src/stripepy/utils/finders.py
@@ -2,41 +2,58 @@
 #
 # SPDX-License-Identifier: MIT
 
+import itertools
+import time
 from functools import partial
 from typing import List, Optional, Tuple
 
 import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import scipy.sparse as ss
+import structlog
 
 from . import TDA
+from .common import pretty_format_elapsed_time
 from .regressions import _compute_wQISA_predictions
 
 
-def find_horizontal_domain(pd, coarse_h_domain, max_width=1e9):
+def find_horizontal_domain(
+    profile: npt.NDArray[float],
+    coarse_h_domain: Tuple[int, int, int],
+    max_width: int = 1e9,
+) -> Tuple[int, int]:
+    """
+    Returns
+    -------
+    Tuple[int, int]
+        the left and right coordinates of the horizontal domain
+    """
 
     # Unpacking:
     MP, L_mP, R_mP = coarse_h_domain
 
     # Left and sides of candidate:
-    L_interval = np.flip(pd[L_mP : MP + 1])
-    R_interval = pd[MP : R_mP + 1]
+    L_interval = np.flip(profile[L_mP : MP + 1])
+    R_interval = profile[MP : R_mP + 1]
 
     # LEFT INTERVAL
-    L_interval_shifted = np.append(L_interval[1:], [max(pd) + 1], axis=0)
+    L_interval_shifted = np.append(L_interval[1:], [max(profile) + 1], axis=0)
     L_bound = np.where(L_interval - L_interval_shifted < 0)[0][0] + 1
     # L_interval_restr = L_interval[:L_bound]
     # L_interval_shifted_restr = L_interval_shifted[:L_bound]
     # L_bound = np.argmax(L_interval_restr - L_interval_shifted_restr) + 1
-    L_bound = min(L_bound, max_width)
+    L_bound = np.minimum(L_bound, max_width)
 
     # RIGHT INTERVAL
-    R_interval_shifted = np.append(R_interval[1:], [max(pd) + 1], axis=0)
+    R_interval_shifted = np.append(R_interval[1:], [max(profile) + 1], axis=0)
     R_bound = np.where(R_interval - R_interval_shifted < 0)[0][0] + 1
     # R_interval_restr = R_interval[:R_bound]
     # R_interval_shifted_restr = R_interval_shifted[:R_bound]
     # R_bound = np.argmax(R_interval_restr - R_interval_shifted_restr) + 1
-    R_bound = min(R_bound, max_width)
+    R_bound = np.minimum(R_bound, max_width)
 
-    return [max(MP - L_bound, 0), min(MP + R_bound, len(pd))]
+    return max(MP - L_bound, 0), min(MP + R_bound, len(profile))
 
 
 def find_lower_v_domain(I, threshold_cut, max_height, min_persistence, it) -> Tuple[List, Optional[List]]:
@@ -114,38 +131,51 @@ def find_upper_v_domain(I, threshold_cut, max_height, min_persistence, it) -> Tu
     return [seed_site - candida_bound[0], seed_site], list(seed_site - np.array(loc_Maxima[:-1]))
 
 
-def find_HIoIs(pd, seed_sites, seed_site_bounds, max_width, map=map):
+def find_HIoIs(
+    pseudodistribution: npt.NDArray[float],
+    seed_sites: npt.NDArray[int],
+    seed_site_bounds: npt.NDArray[int],
+    max_width: int,
+    map_=map,
+    logger=None,
+) -> pd.DataFrame:
     """
-    :param pd:                  acronym for pseudo-distribution, but can be any 1D array representing a uniformly-sample
-                                scalar function works
+    :param pseudodistribution:  1D array representing a uniformly-sample scalar function works
     :param seed_sites:          maximum values in the pseudo-distribution (i.e., genomic coordinates hosting linear
                                 patterns)
     :param seed_site_bounds:    for the i-th entry of seed_sites:
                                 (*) seed_site_bounds[i] is the left boundary
                                 (*) seed_site_bounds[i+1] is the right boundary
     :param max_width:           maximum width allowed
-    :param map:                 alternative implementation of the built-in map function. Can be used to e.g. run this step in parallel by passing multiprocessing.Pool().map.
+    :param map_:                 alternative implementation of the built-in map function. Can be used to e.g. run this step in parallel by passing multiprocessing.Pool().map.
     :return:
-    HIoIs                       list of lists, where each sublist is a pair consisting of the left and right boundaries
+    HIoIs                       a pd.DataFrame the list of left and right boundary for each seed site
     """
     assert len(seed_site_bounds) == len(seed_sites) + 1
 
-    iterable_input = [
+    t0 = time.time()
+    if logger is None:
+        logger = structlog.get_logger()
+
+    iterable_input = (
         (seed_site, seed_site_bounds[num_MP], seed_site_bounds[num_MP + 1])
         for num_MP, seed_site in enumerate(seed_sites)
-    ]
+    )
 
-    HIoIs = list(map(partial(find_horizontal_domain, pd, max_width=max_width), iterable_input))
+    tasks = map_(partial(find_horizontal_domain, pseudodistribution, max_width=max_width), iterable_input)
+    # This efficiently constructs a 2D numpy with shape (N, 2) from a list of 2-element tuples, where N is the number of seed sites.
+    # The first and second columns contains the left and right boundaries of the horizontal domains, respectively.
+    HIoIs = np.fromiter(itertools.chain.from_iterable(tasks), count=2 * len(seed_sites), dtype=int).reshape(-1, 2)
 
-    # Handle possible overlapping intervals:
-    for i in range(len(HIoIs) - 1):
-        current_pair = HIoIs[i]
-        next_pair = HIoIs[i + 1]
+    # Handle possible overlapping intervals by ensuring that the
+    # left bound of interval i + 1 is always greater or equal than the right bound of interval i
+    HIoIs[1:, 0] = np.maximum(HIoIs[1:, 0], HIoIs[:-1, 1])
 
-        if current_pair[1] > next_pair[0]:  # Check for intersection
-            next_pair[0] = current_pair[1]  # Modify the second pair
+    df = pd.DataFrame(data=HIoIs, columns=["left_bound", "right_bound"])
 
-    return HIoIs
+    logger.debug("find_HIoIs took %s", pretty_format_elapsed_time(t0))
+
+    return df
 
 
 def find_VIoIs(

--- a/src/stripepy/utils/finders.py
+++ b/src/stripepy/utils/finders.py
@@ -157,12 +157,12 @@ def find_HIoIs(
     if logger is None:
         logger = structlog.get_logger()
 
-    iterable_input = (
+    params = (
         (seed_site, seed_site_bounds[num_MP], seed_site_bounds[num_MP + 1])
         for num_MP, seed_site in enumerate(seed_sites)
     )
 
-    tasks = map_(partial(find_horizontal_domain, pseudodistribution, max_width=max_width), iterable_input)
+    tasks = map_(partial(find_horizontal_domain, pseudodistribution, max_width=max_width), params)
     # This efficiently constructs a 2D numpy with shape (N, 2) from a list of 2-element tuples, where N is the number of seed sites.
     # The first and second columns contains the left and right boundaries of the horizontal domains, respectively.
     HIoIs = np.fromiter(itertools.chain.from_iterable(tasks), count=2 * len(seed_sites), dtype=int).reshape(-1, 2)

--- a/src/stripepy/utils/regressions.py
+++ b/src/stripepy/utils/regressions.py
@@ -3,14 +3,15 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
+import numpy.typing as npt
 
 
-def _compute_wQISA_predictions(Y, k):
-
+def _compute_wQISA_predictions(Y: npt.NDArray, k: int) -> npt.NDArray[float]:
+    assert k >= 1
     # Control points of a weighted quasi-interpolant spline approximation with a k-NN weight function:
-    kernel = np.full((k,), 1 / k)
+    kernel = np.full(k, 1 / k)
     radius = (k - 1) // 2
-    Y_ext = np.pad(Y.tolist(), (radius, radius), mode="edge")
+    Y_ext = np.pad(Y, (radius, radius), mode="edge")
     predictions = np.convolve(Y_ext, kernel, "valid")
 
     return predictions


### PR DESCRIPTION
On my dev machine the optimization results in a 40% improvement in single-threaded performance.

The time required to estimate stripe witdths for chr1 dropped from 3.413s to 23.947ms.

Supersedes https://github.com/paulsengroup/StripePy/pull/90.

<details>
<summary>Timings</summary>

Baseline:

```
	Command being timed: "venv/bin/stripepy call test/data/4DNFI9GMP2J8.mcool 10000 -o /tmp/stripepy-devel/ --force --verbosity=debug"
	User time (seconds): 116.81
	System time (seconds): 1.79
	Percent of CPU this job got: 103%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:55.06
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 1294200
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 718990
	Voluntary context switches: 35201
	Involuntary context switches: 3854
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

With optimizations:

```
        Command being timed: "venv/bin/stripepy call test/data/4DNFI9GMP2J8.mcool 10000 -o /tmp/stripepy-devel/ --force --verbosity=debug"
        User time (seconds): 81.66
        System time (seconds): 1.47
        Percent of CPU this job got: 104%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:19.38
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1293752
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 566521
        Voluntary context switches: 31337
        Involuntary context switches: 1699
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

</details>