### PR TITLE
[bug] Fix inconsistent results produced on different platforms

### DIFF
--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -24,7 +24,7 @@ from stripepy.utils.progress_bar import initialize_progress_bar
 def _get_datasets(max_size: float, include_private: bool) -> Dict[str, Dict[str, str]]:
     assert not math.isnan(max_size)
 
-    record_id = "14638947"
+    record_id = "14643417"
 
     datasets = {
         "4DNFI3RFZLZ5": {
@@ -68,7 +68,7 @@ def _get_datasets(max_size: float, include_private: bool) -> Dict[str, Dict[str,
         },
         "__results_v2": {
             "url": f"https://zenodo.org/records/{record_id}/files/results_4DNFI9GMP2J8_v2.hdf5?download=1",
-            "md5": "5679919b4a2eaaca685db5bd0db59c80",
+            "md5": "496fb92c1565c83b323e77d6d51ac321",
             "filename": "results_4DNFI9GMP2J8_v2.hdf5",
             "assembly": "hg38",
             "format": "stripepy",

--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -24,7 +24,7 @@ from stripepy.utils.progress_bar import initialize_progress_bar
 def _get_datasets(max_size: float, include_private: bool) -> Dict[str, Dict[str, str]]:
     assert not math.isnan(max_size)
 
-    record_id = "14616548"
+    record_id = "14638947"
 
     datasets = {
         "4DNFI3RFZLZ5": {
@@ -60,7 +60,7 @@ def _get_datasets(max_size: float, include_private: bool) -> Dict[str, Dict[str,
     private_datasets = {
         "__results_v1": {
             "url": f"https://zenodo.org/records/{record_id}/files/results_4DNFI9GMP2J8_v1.hdf5?download=1",
-            "md5": "172872e8de9f35909f87ff33c185a07b",
+            "md5": "8f4566c438b2b8a449393fb3b8fc2636",
             "filename": "results_4DNFI9GMP2J8_v1.hdf5",
             "assembly": "hg38",
             "format": "stripepy",
@@ -68,7 +68,7 @@ def _get_datasets(max_size: float, include_private: bool) -> Dict[str, Dict[str,
         },
         "__results_v2": {
             "url": f"https://zenodo.org/records/{record_id}/files/results_4DNFI9GMP2J8_v2.hdf5?download=1",
-            "md5": "b40e5f929e79cb4a4d3453a59c5a0947",
+            "md5": "5679919b4a2eaaca685db5bd0db59c80",
             "filename": "results_4DNFI9GMP2J8_v2.hdf5",
             "assembly": "hg38",
             "format": "stripepy",

--- a/src/stripepy/cli/view.py
+++ b/src/stripepy/cli/view.py
@@ -38,7 +38,7 @@ def _read_stripes(f: ResultFile, chrom: str) -> pd.DataFrame:
         df1 = pd.concat([geo_lt, bio_lt], axis="columns")
         df2 = pd.concat([geo_ut, bio_ut], axis="columns")
 
-        return pd.concat([df1, df2]).set_index("seed").sort_index()
+        return pd.concat([df1, df2]).set_index("seed").sort_index(kind="stable")
     except Exception as e:
         raise RuntimeError(f'failed to read stripes for chromosome "{chrom}": {e}')
 

--- a/src/stripepy/plot.py
+++ b/src/stripepy/plot.py
@@ -521,10 +521,10 @@ def _fetch_persistence_maximum_points(result: Result, resolution: int, start: in
 
     min_persistence = result.min_persistence
     lt_idx, lt_seeds = fetch(
-        np.sort(TDA(pd_lt, min_persistence=min_persistence)[2]), start // resolution, end // resolution
+        np.sort(TDA(pd_lt, min_persistence=min_persistence)[2], stable=True), start // resolution, end // resolution
     )
     ut_idx, ut_seeds = fetch(
-        np.sort(TDA(pd_ut, min_persistence=min_persistence)[2]), start // resolution, end // resolution
+        np.sort(TDA(pd_ut, min_persistence=min_persistence)[2], stable=True), start // resolution, end // resolution
     )
 
     return {

--- a/src/stripepy/utils/TDA.py
+++ b/src/stripepy/utils/TDA.py
@@ -27,7 +27,7 @@ def TDA(marginal_pd, min_persistence=0):
     )
 
     # Sorting maximum points (and, as a consequence, the corresponding minimum points) w.r.t. persistence:
-    argsorting = np.argsort(list(zip(*filtered_max_points_and_persistence))[1]).tolist()
+    argsorting = np.argsort(list(zip(*filtered_max_points_and_persistence))[1], stable=True).tolist()
 
     if len(filtered_min_points_and_persistence) == 0:
         filtered_min_points = []

--- a/src/stripepy/utils/common.py
+++ b/src/stripepy/utils/common.py
@@ -31,7 +31,7 @@ def sort_based_on_arg0(*vectors: Sequence) -> Tuple[NDArray]:
     if len(vectors[0]) == 0:
         return tuple((np.array(v) for v in vectors))  # noqa
 
-    permutation = np.argsort(vectors[0])
+    permutation = np.argsort(vectors[0], stable=True)
 
     return tuple((np.array(v)[permutation] for v in vectors))  # noqa
 

--- a/src/stripepy/utils/common.py
+++ b/src/stripepy/utils/common.py
@@ -2,16 +2,19 @@
 #
 # SPDX-License-Identifier: MIT
 
+import decimal
 import time
 from typing import Optional, Sequence, Tuple
 
 import numpy as np
+import pandas as pd
 from numpy.typing import NDArray
 
 
-def sort_based_on_arg0(*vectors: Sequence) -> Tuple[NDArray]:
+def sort_values(*vectors: Sequence) -> Tuple[NDArray]:
     """
-    Sort two or more sequences of objects based on the first sequence of objects.
+    Sort two or more sequences of objects as if each sequence was a column in a
+    table and the table was being sorted row-by-row based on values from all columns.
 
     Parameters
     ----------
@@ -31,9 +34,10 @@ def sort_based_on_arg0(*vectors: Sequence) -> Tuple[NDArray]:
     if len(vectors[0]) == 0:
         return tuple((np.array(v) for v in vectors))  # noqa
 
-    permutation = np.argsort(vectors[0], stable=True)
+    df = pd.DataFrame({i: v for i, v in enumerate(vectors)})
+    df.sort_values(by=df.columns.tolist(), inplace=True, kind="stable")
 
-    return tuple((np.array(v)[permutation] for v in vectors))  # noqa
+    return tuple(df[col].to_numpy() for col in df.columns)  # noqa
 
 
 def pretty_format_elapsed_time(t0: float, t1: Optional[float] = None) -> str:
@@ -69,6 +73,34 @@ def pretty_format_elapsed_time(t0: float, t1: Optional[float] = None) -> str:
     minutes = (delta - (hours * 3600)) // 60
     seconds = delta - (hours * 3600) - (minutes * 60)
     return f"{hours:.0f}h:{minutes:.0f}m:{seconds:.3f}s"
+
+
+def truncate_np(v: NDArray[float], places: int) -> NDArray[float]:
+    """
+    Truncate a numpy array to the given number of decimal places.
+    Implementation based on https://stackoverflow.com/a/28323804
+
+    Parameters
+    ----------
+    v: NDArray[float]
+        the numpy array to be truncated
+    places: int
+        the number of decimal places to truncate to
+
+    Returns
+    -------
+    NDArray[float]
+        numpy array with truncated values
+    """
+    assert places >= 0
+
+    if places == 0:
+        return v.round(0)
+
+    with decimal.localcontext() as context:
+        context.rounding = decimal.ROUND_DOWN
+        exponent = decimal.Decimal(str(10**-places))
+        return np.array([float(decimal.Decimal(str(n)).quantize(exponent)) for n in v], dtype=float)
 
 
 def _import_matplotlib():

--- a/src/stripepy/utils/persistence1d.py
+++ b/src/stripepy/utils/persistence1d.py
@@ -41,7 +41,7 @@ def run_persistence(data, level_sets="lower"):
 
     # Number of data to break ties (leftmost index comes first):
     num_elements = len(data)
-    sorted_idx = np.argsort(data, kind="stable")[::-1] if level_sets == "upper" else np.argsort(data, kind="stable")
+    sorted_idx = np.argsort(data, stable=True)[::-1] if level_sets == "upper" else np.argsort(data, stable=True)
 
     # Get a union find data structure:
     uf = UnionFind(num_elements)

--- a/test/integration/common.py
+++ b/test/integration/common.py
@@ -3,6 +3,14 @@
 # SPDX-License-Identifier: MIT
 
 
+import pathlib
+from typing import Sequence
+
+from pandas.testing import assert_frame_equal
+
+from stripepy.IO import ResultFile
+
+
 def matplotlib_avail() -> bool:
     try:
         import matplotlib
@@ -10,3 +18,49 @@ def matplotlib_avail() -> bool:
         return False
 
     return True
+
+
+def _compare_attributes(f1: ResultFile, f2: ResultFile):
+    assert f1.assembly == f2.assembly
+    assert f1.resolution == f2.resolution
+    assert f1.format == f2.format
+    assert f1.normalization == f2.normalization
+    assert f1.chromosomes == f2.chromosomes
+
+    metadata1 = f1.metadata
+    metadata2 = f2.metadata
+
+    metadata1.pop("min-chromosome-size")
+    metadata2.pop("min-chromosome-size")
+
+    assert metadata1 == metadata2
+
+
+def _compare_field(f1: ResultFile, f2: ResultFile, chrom: str, field: str, location: str):
+    assert chrom in f1.chromosomes
+    df1 = f1.get(chrom, field, location)
+    df2 = f2.get(chrom, field, location)
+
+    assert_frame_equal(df1, df2, check_exact=False)
+
+
+def _compare_result(f1: ResultFile, f2: ResultFile, chrom: str, location: str):
+    fields = (
+        "pseudodistribution",
+        "all_minimum_points",
+        "persistence_of_all_minimum_points",
+        "all_maximum_points",
+        "persistence_of_all_maximum_points",
+        "stripes",
+    )
+
+    for field in fields:
+        _compare_field(f1, f2, chrom, field, location)
+
+
+def compare_result_files(reference: pathlib.Path, found: pathlib.Path, chroms: Sequence[str]):
+    with ResultFile(reference) as f1, ResultFile(found) as f2:
+        _compare_attributes(f1, f2)
+        for chrom in chroms:
+            _compare_result(f1, f2, chrom, "LT")
+            _compare_result(f1, f2, chrom, "UT")

--- a/test/integration/test_stripepy_call.py
+++ b/test/integration/test_stripepy_call.py
@@ -37,7 +37,7 @@ class TestStripePyCall:
         resolution = 10_000
 
         chrom_sizes = hictkpy.MultiResFile(testfile).chromosomes()
-        chrom_size_cutoff = sum(chrom_sizes.values()) // len(chrom_sizes)
+        chrom_size_cutoff = chrom_sizes["chr7"] - 1
 
         args = [
             "call",
@@ -70,7 +70,7 @@ class TestStripePyCall:
         resolution = 10_000
 
         chrom_sizes = hictkpy.MultiResFile(testfile).chromosomes()
-        chrom_size_cutoff = max(chrom_sizes.values()) - 1
+        chrom_size_cutoff = chrom_sizes["chr1"] - 1
 
         args = [
             "call",
@@ -101,4 +101,6 @@ class TestStripePyCall:
         outfile = pathlib.Path(tmpdir) / testfile.stem / str(resolution) / "results.hdf5"
 
         assert outfile.is_file()
-        compare_result_files(result_file, outfile, [tuple(chrom_sizes.keys())[0]])
+        compare_result_files(
+            result_file, outfile, [chrom for chrom, size in chrom_sizes.items() if size >= chrom_size_cutoff]
+        )

--- a/test/integration/test_stripepy_download.py
+++ b/test/integration/test_stripepy_download.py
@@ -40,7 +40,7 @@ class TestStripePyDownload:
 
         assert dest.is_file()
 
-        assert _hash_file(dest) == "172872e8de9f35909f87ff33c185a07b"
+        assert _hash_file(dest) == "8f4566c438b2b8a449393fb3b8fc2636"
 
     @staticmethod
     def test_download_random(tmpdir):


### PR DESCRIPTION
Fix two bugs that resulted in different results being returned when running stripepy call on different platform (and potentially even when using different versions of numpy and pandas).

The first bug was caused by not forcing numpy and pandas to use stable sorting algorithms.
The second bug was due to minor difference in FP arithmetic on different architectures.

This first bug resulted in slightly different results produced on macOS and Linux (Windows and Linux produced consistent results).

The second bug resulted in different results when using different architectures (or even different CPUs with the same arch).
