### PR TITLE
Simplify assertion for neighborhood size

### DIFF
--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -187,7 +187,7 @@ def _check_neighborhood(
 ) -> List[int]:
     # TODO rea1991 Change neighborhood size from "matrix" to "genomic" (eg, default of 1 Mb)
     assert 0 <= min_value
-    assert 1 <= neighborhood_size <= len(values)
+    assert 0 < neighborhood_size
     assert 0 <= threshold_percentage <= 1
 
     mask = [0] * len(values)


### PR DESCRIPTION
We now simply check that the neighborhood size is a positive number, while further testing is moved to unit testing.