### PR TITLE
[bug]: fix off-by-one error in code computing stripe biodescriptors

### DIFF
--- a/.github/workflows/build-dockerfile.yml
+++ b/.github/workflows/build-dockerfile.yml
@@ -49,7 +49,7 @@ permissions:
 jobs:
   cache-test-datasets:
     name: Cache test dataset
-    uses: paulsengroup/StripePy/.github/workflows/cache-test-datasets.yml@main
+    uses: paulsengroup/StripePy/.github/workflows/cache-test-datasets.yml@4e2b8ef900132afa172530d98a129596119ec348
 
   build-dockerfile:
     name: Build Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
   cache-test-datasets:
     name: Cache test datasets
-    uses: paulsengroup/StripePy/.github/workflows/cache-test-datasets.yml@main
+    uses: paulsengroup/StripePy/.github/workflows/cache-test-datasets.yml@4e2b8ef900132afa172530d98a129596119ec348
 
   ci:
     name: CI

--- a/src/stripepy/cli/download.py
+++ b/src/stripepy/cli/download.py
@@ -24,7 +24,7 @@ from stripepy.utils.progress_bar import initialize_progress_bar
 def _get_datasets(max_size: float, include_private: bool) -> Dict[str, Dict[str, str]]:
     assert not math.isnan(max_size)
 
-    record_id = "14643417"
+    record_id = "14762415"
 
     datasets = {
         "4DNFI3RFZLZ5": {
@@ -60,7 +60,7 @@ def _get_datasets(max_size: float, include_private: bool) -> Dict[str, Dict[str,
     private_datasets = {
         "__results_v1": {
             "url": f"https://zenodo.org/records/{record_id}/files/results_4DNFI9GMP2J8_v1.hdf5?download=1",
-            "md5": "8f4566c438b2b8a449393fb3b8fc2636",
+            "md5": "03bca8d430191aaf3c90a4bc22a8c579",
             "filename": "results_4DNFI9GMP2J8_v1.hdf5",
             "assembly": "hg38",
             "format": "stripepy",
@@ -68,7 +68,7 @@ def _get_datasets(max_size: float, include_private: bool) -> Dict[str, Dict[str,
         },
         "__results_v2": {
             "url": f"https://zenodo.org/records/{record_id}/files/results_4DNFI9GMP2J8_v2.hdf5?download=1",
-            "md5": "496fb92c1565c83b323e77d6d51ac321",
+            "md5": "dd14a2f69b337c40727d414d85e2f0a4",
             "filename": "results_4DNFI9GMP2J8_v2.hdf5",
             "assembly": "hg38",
             "format": "stripepy",

--- a/src/stripepy/utils/stripe.py
+++ b/src/stripepy/utils/stripe.py
@@ -154,12 +154,12 @@ class Stripe(object):
         convex_comb = self._compute_convex_comp()
 
         if self.lower_triangular:
-            rows = slice(convex_comb, self._bottom_bound)
-            cols = slice(self._left_bound, self._right_bound)
+            rows = slice(convex_comb, min(self._bottom_bound + 1, I.shape[0]))
+            cols = slice(self._left_bound, min(self._right_bound + 1, I.shape[1]))
             return I[rows, :].tocsc()[:, cols].toarray()
 
-        rows = slice(self._top_bound, convex_comb)
-        cols = slice(self._left_bound, self._right_bound)
+        rows = slice(self._top_bound, min(convex_comb + 1, I.shape[0]))
+        cols = slice(self._left_bound, min(self._right_bound + 1, I.shape[1]))
         return I[rows, :].tocsc()[:, cols].toarray()
 
     @staticmethod

--- a/test/integration/test_stripepy_download.py
+++ b/test/integration/test_stripepy_download.py
@@ -40,7 +40,7 @@ class TestStripePyDownload:
 
         assert dest.is_file()
 
-        assert _hash_file(dest) == "8f4566c438b2b8a449393fb3b8fc2636"
+        assert _hash_file(dest) == "03bca8d430191aaf3c90a4bc22a8c579"
 
     @staticmethod
     def test_download_random(tmpdir):

--- a/test/integration/test_stripepy_view.py
+++ b/test/integration/test_stripepy_view.py
@@ -46,4 +46,4 @@ class TestStripePyView:
 
             assert len(df.columns) == len(cols)
             assert len(df) == len(df[~df.isnull().values])
-            assert len(df) == 19761
+            assert len(df) == 18625


### PR DESCRIPTION
Fix an off by one error in the logic that slicing the genome-wide sparse matrix prior to computing a stripe biodescriptors.

As can be seen in the scatterplots, this rarely changes the biodescriptors in a significant way:

![scatters](https://github.com/user-attachments/assets/0a84c4f2-1f76-404d-a0ed-0f074cf57a55)


[attachements.tar.gz](https://github.com/user-attachments/files/18561878/attachements.tar.gz)

