### PR TITLE
[bug]: correct bound checking in stripe plotting code

### DIFF
--- a/src/stripepy/plot.py
+++ b/src/stripepy/plot.py
@@ -681,8 +681,13 @@ def _plot_hic_matrix_with_stripes(
         geo_descriptors_lt = geo_descriptors_lt[mask_lt]
         geo_descriptors_ut = geo_descriptors_ut[mask_ut]
 
-    geo_descriptors_lt = geo_descriptors_lt[geo_descriptors_lt["right_bound"].between(start, end, inclusive="both")]
-    geo_descriptors_ut = geo_descriptors_ut[geo_descriptors_ut["right_bound"].between(start, end, inclusive="both")]
+    left_bound_within_region = geo_descriptors_lt["left_bound"].between(start, end, inclusive="both")
+    right_bound_within_region = geo_descriptors_lt["right_bound"].between(start, end, inclusive="both")
+    geo_descriptors_lt = geo_descriptors_lt[left_bound_within_region & right_bound_within_region]
+
+    left_bound_within_region = geo_descriptors_ut["left_bound"].between(start, end, inclusive="both")
+    right_bound_within_region = geo_descriptors_ut["right_bound"].between(start, end, inclusive="both")
+    geo_descriptors_ut = geo_descriptors_ut[left_bound_within_region & right_bound_within_region]
 
     outlines_lt = [
         (min(lb - start, chrom_size), min(rb - start, chrom_size), min(bb - tb, chrom_size))

--- a/src/stripepy/stripepy.py
+++ b/src/stripepy/stripepy.py
@@ -1198,7 +1198,10 @@ def _get_stripes(
     descriptors_ut["rel_change"] = result.get_stripe_bio_descriptors("UT")["rel_change"].iloc[descriptors_ut.index]
 
     df = pd.concat([descriptors_lt, descriptors_ut])
-    return df[df["left_bound"].between(start, end, inclusive="both")]
+
+    left_bound_within_roi = df["left_bound"].between(start, end, inclusive="both")
+    right_bound_within_roi = df["right_bound"].between(start, end, inclusive="both")
+    return df[left_bound_within_roi & right_bound_within_roi]
 
 
 def _plot_stripes(


### PR DESCRIPTION
Ensure only stripes that are fully enclosed in a given region of interest are plotted using `stripepy plot` or `stripepy call ... --roi=*`.