### PR TITLE
[perf]: take advantage of the new hictkpy.File.fetch() capabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ keywords = [
 requires-python = ">=3.9"
 dependencies = [
     "h5py >3, <4",
-    "hictkpy[scipy] >=1.1, <2",
+    "hictkpy[scipy] >=1.2, <2",
     "numpy >=2, <3",
     "pandas >=2.0, <3",
     "scipy >=1.10, <2",

--- a/src/stripepy/data_structures/concurrent.py
+++ b/src/stripepy/data_structures/concurrent.py
@@ -479,7 +479,11 @@ class IOManager(object):
         logger = structlog.get_logger().bind(chrom=chrom_name, step="IO")
 
         logger.info("fetching interactions using normalization=%s", normalization)
-        matrix = hictkpy.File(path, resolution=resolution).fetch(chrom_name, normalization=normalization).to_csr()
+        f = hictkpy.File(path, resolution=resolution)
+        chrom_size = f.chromosomes()[chrom_name]
+        diagonal_band_width = (genomic_belt // resolution) + 1 if genomic_belt < chrom_size else None
+        matrix = f.fetch(chrom_name, normalization=normalization, diagonal_band_width=diagonal_band_width).to_csr()
+
         logger.info("fetched %d pixels in %s", matrix.count_nonzero(), pretty_format_elapsed_time(t0))
 
         logger = structlog.get_logger().bind(chrom=chrom_name, step=(1,))


### PR DESCRIPTION
On my machine, this yields a ~25% perf improvement and a 60% reduction in peak memory usage when processing 4DNFI9GMP2J8.mcool at 10kb using 16 CPU cores (note that this applies to the genome-wide version of the .mcool, not the minified version we use for testing).
Running stripepy on the same file converted to .hic v9 using hictk convert yields an even better perf improvement of approx 40%.