### PR TITLE
[deps]: override the default process start method when appropriate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install package
         run: |
           if [[ ${{ matrix.minimal_install }} == 'true' ]]; then
-            pip install '.' pytest pytest-cov
+            pip install '.' pyarrow pytest pytest-cov
           else
             pip install '.[all,test]'
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ norecursedirs = [
 ]
 filterwarnings = [
   'ignore:This process .* is multi-threaded, use of fork\(\) may lead to deadlocks in the child:DeprecationWarning',
+  'ignore:hictkpy. detected a call to fork\(\)..*:UserWarning',
 ]
 
 [tool.coverage.run]

--- a/test/integration/common.py
+++ b/test/integration/common.py
@@ -16,7 +16,11 @@ from stripepy.io import compare_result_files as _compare_result_files
 def stripepy_main(args) -> int:
     from stripepy.main import main
 
-    return main(args, no_telemetry=True)
+    return main(
+        args,
+        no_telemetry=True,
+        skip_set_process_start_method=True,
+    )
 
 
 def matplotlib_avail() -> bool:


### PR DESCRIPTION
This is required to avoid warnings raised by hictkpy when method=fork.